### PR TITLE
fix: fix ts error, use modern TS configs

### DIFF
--- a/src/next-video.tsx
+++ b/src/next-video.tsx
@@ -1,7 +1,11 @@
 'use client';
 
+// todo: fix mux-player to work with moduleResolution: 'nodenext'?
+// @ts-ignore
 import MuxPlayer from '@mux/mux-player-react';
+// @ts-ignore
 import type { MuxPlayerProps } from '@mux/mux-player-react';
+
 import { Asset } from './assets.js';
 
 declare module 'react' {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2019",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
@@ -10,7 +10,7 @@
     "outDir": "dist",
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
@@ -25,5 +25,5 @@
     }
   },
   "include": ["**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "video-types"]
 }


### PR DESCRIPTION
- fixes a overwrite error caused by video-types folder
- uses target: 2019 to not include a bunch of heavy polyfills in the dist build
- uses the modern module resolution https://www.typescriptlang.org/tsconfig#moduleResolution
> 'node10' (previously called 'node') for Node.js versions older than v10, which only support CommonJS require. You probably won’t need to use node10 in modern code.

the old module resolution `node` was causing issues when I tried to use a dynamic `import()`.