### PR TITLE
Only re-sync existing assets that are not ready or errored. Fixes #28

### DIFF
--- a/src/cli/sync.ts
+++ b/src/cli/sync.ts
@@ -80,7 +80,12 @@ export async function handler(argv: Arguments) {
       const assetPath = path.join(parsedPath.dir, parsedPath.name);
       const existingAsset = await getAsset(assetPath);
 
-      return callHandler('local.video.added', existingAsset);
+      // If the existing asset is 'pending', 'uploading', or 'processing', run
+      // it back through the local video handler.
+      const assetStatus = existingAsset?.status;
+      if (assetStatus && ['pending', 'uploading', 'processing'].includes(assetStatus)) {
+        return callHandler('local.video.added', existingAsset);
+      }
     };
 
     const unprocessedFilter = (file: string) => {


### PR DESCRIPTION
Only call the handler if the asset status is a state where the handler can actually do anything.