### PR TITLE
Change /video/files dir to /videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,10 @@ Next video is a react component for adding video to your [next.js](https://githu
 
 ```tsx
 import Video from '@mux/next-video';
-import myVideo from '/video/files/myVideo.mp4';
- 
+import myVideo from '/videos/myVideo.mp4';
+
 export default function Page() {
-  return (
-    <Video src={myVideo} />
-  )
+  return <Video src={myVideo} />;
 }
 ```
 
@@ -29,9 +27,9 @@ npm install @mux/next-video
 npx @mux/next-video init
 ```
 
-This will create a `/video/files` directory in your project which is where you will put all video source files.
+This will create a `/videos` directory in your project which is where you will put all video source files.
 
-It will also add a .gitignore file to the `/video` directory that ignores video files. Videos, particularly any of reasonable size, shouldn't be stored/tracked by git. Alternatively, if you'd like to store the original files you can remove the added gitignore lines and install [git-lfs](https://git-lfs.github.com/).
+It will also add a .gitignore file to the `/videos` directory that ignores video files. Videos, particularly any of reasonable size, shouldn't be stored/tracked by git. Alternatively, if you'd like to store the original files you can remove the added gitignore lines and install [git-lfs](https://git-lfs.github.com/).
 
 ### Remote storage and optimization
 
@@ -62,13 +60,13 @@ module.exports = withNextVideo(nextConfig);
 
 ### Local videos
 
-Add videos locally to the `video/files` directory then run `npx @mux/next-video sync`. The videos will be automatically uploaded to remote storage and optimized. You'll notice `video/files/[file-name].json` files are also created. These are used to map your local video files to the new, remote-hosted video assets. These json files must be checked into git.
+Add videos locally to the `/videos` directory then run `npx @mux/next-video sync`. The videos will be automatically uploaded to remote storage and optimized. You'll notice `/videos/[file-name].json` files are also created. These are used to map your local video files to the new, remote-hosted video assets. These json files must be checked into git.
 
 ```
 npx @mux/next-video sync
 ```
 
-You can also add `@mux/next-video sync -w` to the dev script to automatically sync videos as they're added to `/video/files` while the dev server is running.
+You can also add `@mux/next-video sync -w` to the dev script to automatically sync videos as they're added to `/videos` while the dev server is running.
 
 ```js
 // package.json
@@ -77,16 +75,14 @@ You can also add `@mux/next-video sync -w` to the dev script to automatically sy
   },
 ```
 
-Now you can use the `<Video>` component in your application. Let's say you've added a file called `awesome-video.mp4` to `video/files`
+Now you can use the `<Video>` component in your application. Let's say you've added a file called `awesome-video.mp4` to `/videos`
 
 ```tsx
 import Video from '@mux/next-video';
-import awesomeVideo from '/video/files/awesome-video.mp4';
+import awesomeVideo from '/videos/awesome-video.mp4';
 
 export default function Page() {
-  return (
-    <Video src={awesomeVideo} />
-  )
+  return <Video src={awesomeVideo} />;
 }
 ```
 
@@ -100,9 +96,7 @@ For videos that are already hosted remotely (for example on AWS S3), set the `sr
 import Video from '@mux/next-video';
 
 export default function Page() {
-  return (
-    <Video src="https://www.mydomain.com/remote-video.mp4" />
-  )
+  return <Video src="https://www.mydomain.com/remote-video.mp4" />;
 }
 ```
 

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -7,12 +7,14 @@ import path from 'node:path';
 
 import * as log from '../logger.js';
 
-const GITIGNORE_CONTENTS = `files/*
-!files/*.json`;
+const GITIGNORE_CONTENTS = `*
+!*.json
+!*.js
+!*.ts`;
 
 const TYPES_FILE_CONTENTS = `/// <reference types="@mux/next-video/video-types/global" />\n`;
 
-const DEFAULT_DIR = 'video';
+const DEFAULT_DIR = 'videos';
 
 async function preInitCheck(dir: string) {
   try {
@@ -28,7 +30,7 @@ async function preInitCheck(dir: string) {
 }
 
 async function createVideoDir(dir: string) {
-  const fullPath = path.join(process.cwd(), dir, 'files');
+  const fullPath = path.join(process.cwd(), dir);
 
   await mkdir(fullPath, { recursive: true });
   await writeFile(path.join(dir, '.gitignore'), GITIGNORE_CONTENTS);
@@ -87,7 +89,7 @@ export async function handler(argv: Arguments) {
 
   await createVideoDir(baseDir);
 
-  changes.push(`Created ${baseDir}/files directory.`);
+  changes.push(`Created ${baseDir} directory.`);
 
   if (ts) {
     await createTSFile();

--- a/src/cli/sync.ts
+++ b/src/cli/sync.ts
@@ -11,7 +11,7 @@ import { createAsset, getAsset } from '../assets.js';
 
 export const command = 'sync';
 export const desc =
-  'Checks for new video files in the files directory, uploads them, and checks any existing assets for updates.';
+  'Checks for new video files in the videos directory, uploads them, and checks any existing assets for updates.';
 
 export function builder(yargs: Argv) {
   return yargs.options({
@@ -23,7 +23,7 @@ export function builder(yargs: Argv) {
     },
     watch: {
       alias: 'w',
-      describe: 'Watch the files directory for changes.',
+      describe: 'Watch the videos directory for changes.',
       type: 'boolean',
       default: false,
     },
@@ -50,7 +50,7 @@ function watcher(dir: string) {
 }
 
 export async function handler(argv: Arguments) {
-  const directoryPath = path.join(process.cwd(), argv.dir as string, 'files');
+  const directoryPath = path.join(process.cwd(), argv.dir as string);
 
   try {
     const files = await readdir(directoryPath);
@@ -106,7 +106,7 @@ export async function handler(argv: Arguments) {
     log.success(`Processed (or resumed processing) ${processed.length} videos.`);
 
     if (argv.watch) {
-      log.info('Watching for changes in the files directory:', directoryPath);
+      log.info('Watching for changes in the videos directory:', directoryPath);
       watcher(directoryPath);
     }
   } catch (err: any) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,4 @@
 import path from 'node:path';
 
-export const VIDEO_PATH = path.join(process.cwd(), '/video');
-export const CONFIG_PATH = path.join(VIDEO_PATH, '/assets.json');
-export const FILES_PATH = path.join(VIDEO_PATH, '/files');
+export const VIDEOS_PATH = path.join(process.cwd(), '/videos');
+export const CONFIG_PATH = path.join(VIDEOS_PATH, '/assets.json');

--- a/src/next-video.tsx
+++ b/src/next-video.tsx
@@ -20,7 +20,7 @@ interface NextVideoProps extends Omit<MuxPlayerProps, 'src'> {
 }
 
 const DEV_MODE = process.env.NODE_ENV === 'development';
-const FILES_FOLDER = 'video/files/';
+const FILES_FOLDER = 'videos/';
 
 const toSymlinkPath = (path?: string) => {
   return path?.replace(FILES_FOLDER, `_${FILES_FOLDER}`);

--- a/src/with-next-video.ts
+++ b/src/with-next-video.ts
@@ -3,16 +3,16 @@ import symlinkDir from 'symlink-dir';
 import path from 'node:path';
 import fs from 'node:fs/promises';
 
-import { VIDEO_PATH } from './constants.js';
+import { VIDEOS_PATH } from './constants.js';
 
 export default async function withNextVideo(nextConfig: any) {
   if (process.argv[2] === 'dev') {
-    const TMP_PUBLIC_VIDEO_PATH = path.join(process.cwd(), 'public/_video');
+    const TMP_PUBLIC_VIDEOS_PATH = path.join(process.cwd(), 'public/_videos');
 
-    await symlinkDir(VIDEO_PATH, TMP_PUBLIC_VIDEO_PATH);
+    await symlinkDir(VIDEOS_PATH, TMP_PUBLIC_VIDEOS_PATH);
 
     process.on('exit', async () => {
-      await fs.unlink(TMP_PUBLIC_VIDEO_PATH);
+      await fs.unlink(TMP_PUBLIC_VIDEOS_PATH);
     });
   }
 


### PR DESCRIPTION
We had one suggestion to call the dir `/videos` to match what similar projects do.

We also had a friction log where multiple levels of directories caused friction in the directory setup process.

While the original design was meant to account for future config files, we're deciding to solve that in a different way in the future.