### PR TITLE
automatically source .env and .env.local

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,9 +24,11 @@
         "next-video": "dist/cli.js"
       },
       "devDependencies": {
+        "@types/dotenv-flow": "^3.2.0",
         "@types/node": "^20.4.5",
         "@types/react": "^18.2.16",
         "@types/yargs": "^17.0.24",
+        "dotenv-flow": "^3.2.0",
         "react": "^18.2.0",
         "tsx": "^3.12.7",
         "typescript": "^5.1.6"
@@ -324,6 +326,12 @@
         "media-tracks": "0.2.3",
         "mux-embed": "^4.24.0"
       }
+    },
+    "node_modules/@types/dotenv-flow": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@types/dotenv-flow/-/dotenv-flow-3.2.0.tgz",
+      "integrity": "sha512-A79hbPwocbYkcTwGcDOFbKDuqyVo5mLAz/6Iq465YZ7R7Go5bT1PIM8I2jlPQkaD9u9fbotGVLkUPhX+9XUHfw==",
+      "dev": true
     },
     "node_modules/@types/mute-stream": {
       "version": "0.0.1",
@@ -809,6 +817,27 @@
       "dependencies": {
         "base-64": "^0.1.0",
         "md5": "^2.3.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/dotenv-flow": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv-flow/-/dotenv-flow-3.2.0.tgz",
+      "integrity": "sha512-GEB6RrR4AbqDJvNSFrYHqZ33IKKbzkvLYiD5eo4+9aFXr4Y4G+QaFrB/fNp0y6McWBmvaPn3ZNjIufnj8irCtg==",
+      "dev": true,
+      "dependencies": {
+        "dotenv": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/ecdsa-sig-formatter": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,11 +24,11 @@
         "next-video": "dist/cli.js"
       },
       "devDependencies": {
+        "@next/env": "^13.4.19",
         "@types/dotenv-flow": "^3.2.0",
         "@types/node": "^20.4.5",
         "@types/react": "^18.2.16",
         "@types/yargs": "^17.0.24",
-        "dotenv-flow": "^3.2.0",
         "react": "^18.2.0",
         "tsx": "^3.12.7",
         "typescript": "^5.1.6"
@@ -326,6 +326,12 @@
         "media-tracks": "0.2.3",
         "mux-embed": "^4.24.0"
       }
+    },
+    "node_modules/@next/env": {
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.19.tgz",
+      "integrity": "sha512-FsAT5x0jF2kkhNkKkukhsyYOrRqtSxrEhfliniIq0bwWbuXLgyt3Gv0Ml+b91XwjwArmuP7NxCiGd++GGKdNMQ==",
+      "dev": true
     },
     "node_modules/@types/dotenv-flow": {
       "version": "3.2.0",
@@ -817,27 +823,6 @@
       "dependencies": {
         "base-64": "^0.1.0",
         "md5": "^2.3.0"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/dotenv-flow": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv-flow/-/dotenv-flow-3.2.0.tgz",
-      "integrity": "sha512-GEB6RrR4AbqDJvNSFrYHqZ33IKKbzkvLYiD5eo4+9aFXr4Y4G+QaFrB/fNp0y6McWBmvaPn3ZNjIufnj8irCtg==",
-      "dev": true,
-      "dependencies": {
-        "dotenv": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
       }
     },
     "node_modules/ecdsa-sig-formatter": {

--- a/package.json
+++ b/package.json
@@ -48,11 +48,11 @@
     }
   },
   "devDependencies": {
+    "@next/env": "^13.4.19",
     "@types/dotenv-flow": "^3.2.0",
     "@types/node": "^20.4.5",
     "@types/react": "^18.2.16",
     "@types/yargs": "^17.0.24",
-    "dotenv-flow": "^3.2.0",
     "react": "^18.2.0",
     "tsx": "^3.12.7",
     "typescript": "^5.1.6"

--- a/package.json
+++ b/package.json
@@ -48,9 +48,11 @@
     }
   },
   "devDependencies": {
+    "@types/dotenv-flow": "^3.2.0",
     "@types/node": "^20.4.5",
     "@types/react": "^18.2.16",
     "@types/yargs": "^17.0.24",
+    "dotenv-flow": "^3.2.0",
     "react": "^18.2.0",
     "tsx": "^3.12.7",
     "typescript": "^5.1.6"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,8 +2,6 @@
 import dotenv from 'dotenv-flow';
 dotenv.config();
 
-console.log(process.env.FOO);
-
 import yargs from 'yargs/yargs';
 
 import * as init from './cli/init.js';

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,8 +2,6 @@
 import nextEnv from '@next/env';
 nextEnv.loadEnvConfig(process.cwd());
 
-console.log(process.env.BAR);
-
 import yargs from 'yargs/yargs';
 
 import * as init from './cli/init.js';

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
-import dotenv from 'dotenv-flow';
-dotenv.config();
+import nextEnv from '@next/env';
+nextEnv.loadEnvConfig(process.cwd());
+
+console.log(process.env.BAR);
 
 import yargs from 'yargs/yargs';
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,9 @@
 #!/usr/bin/env node
+import dotenv from 'dotenv-flow';
+dotenv.config();
+
+console.log(process.env.FOO);
+
 import yargs from 'yargs/yargs';
 
 import * as init from './cli/init.js';


### PR DESCRIPTION
Came up as a friction point a couple of times. Since we have to be in our own process, we don't get to rely on Next's sourcing of .env files. ~[dotenv-flow](https://github.com/kerimdzhanov/dotenv-flow) seems to be pretty close to the Next approach, so starting there.~ Nevermind, for now we'll just use [@next/env](https://github.com/vercel/next.js/blob/canary/packages/next-env/index.ts) so we can be sure we're following their pattern.

Closes #26.