### PR TITLE
Fix default directory name

### DIFF
--- a/src/cli/sync.ts
+++ b/src/cli/sync.ts
@@ -19,7 +19,7 @@ export function builder(yargs: Argv) {
       alias: 'd',
       describe: 'The directory you initialized next-video with.',
       type: 'string',
-      default: 'video',
+      default: 'videos',
     },
     watch: {
       alias: 'w',


### PR DESCRIPTION
Init did create a `videos` folder, but it looks like I missed this in the directory name change plural?

<img width="504" alt="image" src="https://github.com/muxinc/next-video/assets/166/386f13ad-23f2-4633-93f3-9aafb17a9500">
