### PR TITLE
fix: optional controls prop

### DIFF
--- a/src/next-video.tsx
+++ b/src/next-video.tsx
@@ -14,7 +14,7 @@ declare module 'react' {
 
 interface NextVideoProps extends Omit<MuxPlayerProps, 'src'> {
   src: string | Asset;
-  controls: boolean;
+  controls?: boolean;
   blurDataURL?: string;
 
   /**
@@ -33,7 +33,7 @@ const toSymlinkPath = (path?: string) => {
 }
 
 export default function NextVideo(props: NextVideoProps) {
-  let { src, poster, blurDataURL, sizes = '100vw', ...rest } = props;
+  let { src, poster, blurDataURL, sizes = '100vw', controls = true, ...rest } = props;
   const playerProps: MuxPlayerProps = rest;
   let status: string | undefined;
   let srcset: string | undefined;


### PR DESCRIPTION
Our readme's example doesn't have a `controls` prop but our type defines it as required so TS complains using our example. This defaults it to true and makes it optional (should it default to false?).

<img width="850" alt="image" src="https://github.com/muxinc/next-video/assets/9952680/21325c9b-39ef-49bf-9158-4ec455d37941">
