### PR TITLE
add explicit installation step back to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ export default function Page() {
 
 ```bash
 cd your-next-app
+
+# If your project is using NPM (the default for Next.js)
+npm install --save-dev @mux/next-video
+
+# If your project is using Yarn
+yarn add --dev @mux/next-video
+
+# If your project is using pnpm
+pnpm add --D @mux/next-video
+
 npx @mux/next-video init
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ export default function Page() {
 
 ## Setup
 
+### Install the package
+
 ```bash
 cd your-next-app
 
@@ -32,7 +34,11 @@ yarn add --dev @mux/next-video
 
 # If your project is using pnpm
 pnpm add --D @mux/next-video
+```
 
+### Run the init wizard
+
+```bash
 npx @mux/next-video init
 ```
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "cli": "node --loader tsx --no-warnings ./src/cli",
     "test": "glob -c \"node --loader tsx --no-warnings --test\" \"./tests/**/*.test.ts\""
   },
-  "bin": "./dist/cli.js",
+  "bin": {
+    "@mux/next-video": "./dist/cli.js"
+  },
   "files": [
     "dist",
     "video-types"


### PR DESCRIPTION
Added the ability for us to automatically determine the package manager and install it, but the explicit step is safer up front for now and gets around at least one friction log stumble.