### PR TITLE
fix: bin name without scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test": "glob -c \"node --loader tsx --no-warnings --test\" \"./tests/**/*.test.ts\""
   },
   "bin": {
-    "@mux/next-video": "./dist/cli.js"
+    "next-video": "./dist/cli.js"
   },
   "files": [
     "dist",


### PR DESCRIPTION
worth a shot but not sure if it will have an impact on the "npx without first install" bug

https://github.com/npm/cli/blob/d7265045730555c03b3142c004c7438e9577028c/workspaces/libnpmexec/test/get-bin-from-manifest.js#L5-L16

according to NPM tests the scope should not be included

```js
t.test('extract scope from manifest name with multiple bins', t => {
  const bin = getBinFromManifest({
    name: '@npmcli/foo',
    bin: {
      foo: 'foo',
      bar: 'bar',
    },
  })

  t.equal(bin, 'foo', 'should pick same name as package')
  t.end()
})
```

(also sorry @mmcc, I remember making the case to you it should be the same name)

it seems to pick the command if there is just 1 or if the pkg name is the same

