### PR TITLE
fix: add media metadata via ffprobe-static

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@next/env": "^13.4.19",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
+        "ffprobe-static": "^3.1.0",
         "magicast": "^0.2.10",
         "sharp": "^0.32.5",
         "symlink-dir": "^5.1.1",
@@ -1187,6 +1188,11 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.0.tgz",
       "integrity": "sha512-IgfweLvEpwyA4WgiQe9Nx6VV2QkML2NkvZnk1oKnIzXgXdWxuhF7zw4DvLTPZJn6PIUneiAXPF24QmoEqHTjyw=="
+    },
+    "node_modules/ffprobe-static": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ffprobe-static/-/ffprobe-static-3.1.0.tgz",
+      "integrity": "sha512-Dvpa9uhVMOYivhHKWLGDoa512J751qN1WZAIO+Xw4L/mrUSPxS4DApzSUDbCFE/LUq2+xYnznEahTd63AqBSpA=="
     },
     "node_modules/figures": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@next/env": "^13.4.19",
     "chalk": "^4.1.2",
     "chokidar": "^3.5.3",
+    "ffprobe-static": "^3.1.0",
     "magicast": "^0.2.10",
     "sharp": "^0.32.5",
     "symlink-dir": "^5.1.1",

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -9,7 +9,11 @@ export interface Asset {
   externalIds?: {
     [key: string]: string; // { uploadId, playbackId, assetId }
   };
+  aspectRatio?: string;
   blurDataURL?: string;
+  width?: number;
+  height?: number;
+  duration?: string;
   createdAt?: number;
   updatedAt?: number;
 }

--- a/src/next-video.tsx
+++ b/src/next-video.tsx
@@ -17,6 +17,7 @@ interface NextVideoProps extends Omit<MuxPlayerProps, 'src'> {
   width?: number;
   height?: number;
   controls?: boolean;
+  aspectRatio?: string;
   blurDataURL?: string;
 
   /**
@@ -40,6 +41,7 @@ export default function NextVideo(props: NextVideoProps) {
     width,
     height,
     poster,
+    aspectRatio,
     blurDataURL,
     sizes = '100vw',
     controls = true,
@@ -56,6 +58,7 @@ export default function NextVideo(props: NextVideoProps) {
     status = src.status;
 
     let playbackId = src.externalIds?.playbackId;
+    aspectRatio = aspectRatio ?? src.aspectRatio;
 
     if (status === 'ready' && playbackId) {
       playerProps.playbackId = playbackId;
@@ -111,6 +114,7 @@ export default function NextVideo(props: NextVideoProps) {
         poster=""
         style={{
           '--controls': controls === false ? 'none' : undefined,
+          aspectRatio: aspectRatio !== '16/9' ? aspectRatio : undefined,
           width,
           height,
         }}


### PR DESCRIPTION
related #22

ffprobe-static includes binaries for each platform
https://github.com/eugeneware/ffmpeg-static/tree/master/packages/ffprobe-static