### PR TITLE
feat: add (string & import) remote src support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,32 @@ While a video is being uploaded and processed, `<Video>` will attempt to play th
 
 ### Remote videos
 
-For videos that are already hosted remotely (for example on AWS S3), set the `src` attribute to the URL of the remote file.
+For videos that are already hosted remotely (for example on AWS S3), import the remote URL and refresh the page.
+This creates a local JSON file in the `/videos` folder and the sync script will start uploading the video.
+
+```tsx
+import Video from '@mux/next-video';
+import awesomeVideo from 'https://www.mydomain.com/remote-video.mp4';
+
+export default function Page() {
+  return <Video src={awesomeVideo} />;
+}
+```
+
+If the hosted video is a single file like an MP4, the file will be automatically optimized for better deliverability and compatibility.
+
+#### Alternative
+
+In some cases you might not have the remote video URL's available at the time of import.
+
+That can be solved by creating a new API endpoint in your Next.js app for `/api/video` with the following code.
+
+```js
+// Pages router: pages/api/video/[[...handler]].js
+export { default } from '@mux/next-video/request-handler'
+```
+
+Then set the `src` attribute to the URL of the remote video, refresh the page and the video will start processing.
 
 ```tsx
 import Video from '@mux/next-video';
@@ -141,10 +166,6 @@ export default function Page() {
 }
 ```
 
-If the hosted video is a single file like an MP4, the file will be automatically optimized for better deliverability and compatibility.
-
-If the hosted file is an adaptive manifest, like HLS or DASH, NextVideo will treat the video as if it has already been optimized.
-
 ## Roadmap
 
 ### v0
@@ -152,7 +173,7 @@ If the hosted file is an adaptive manifest, like HLS or DASH, NextVideo will tre
 - [x] Automatic video optimzation
 - [x] Delivery via a CDN
 - [x] Automatically upload and process local source files
-- [ ] Automatically process remote hosted source files
+- [x] Automatically process remote hosted source files
 
 ### v1
 

--- a/README.md
+++ b/README.md
@@ -151,8 +151,17 @@ In some cases you might not have the remote video URL's available at the time of
 
 That can be solved by creating a new API endpoint in your Next.js app for `/api/video` with the following code.
 
+**App router (Next.js >=13)**
+
 ```js
-// Pages router: pages/api/video/[[...handler]].js
+// app/api/video/route.js
+export { GET } from '@mux/next-video/request-handler'
+```
+
+**Pages router (Next.js)**
+
+```js
+// pages/api/video/[[...handler]].js
 export { default } from '@mux/next-video/request-handler'
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@types/react": "^18.2.16",
         "@types/yargs": "^17.0.24",
         "glob": "^10.3.3",
+        "next": "^13.5.2",
         "react": "^18.2.0",
         "tsx": "^3.12.7",
         "typescript": "^5.1.6"
@@ -466,9 +467,153 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.19.tgz",
-      "integrity": "sha512-FsAT5x0jF2kkhNkKkukhsyYOrRqtSxrEhfliniIq0bwWbuXLgyt3Gv0Ml+b91XwjwArmuP7NxCiGd++GGKdNMQ=="
+      "version": "13.5.2",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.2.tgz",
+      "integrity": "sha512-dUseBIQVax+XtdJPzhwww4GetTjlkRSsXeQnisIJWBaHsnxYcN2RGzsPHi58D6qnkATjnhuAtQTJmR1hKYQQPg=="
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "13.5.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.2.tgz",
+      "integrity": "sha512-7eAyunAWq6yFwdSQliWMmGhObPpHTesiKxMw4DWVxhm5yLotBj8FCR4PXGkpRP2tf8QhaWuVba+/fyAYggqfQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "13.5.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.2.tgz",
+      "integrity": "sha512-WxXYWE7zF1ch8rrNh5xbIWzhMVas6Vbw+9BCSyZvu7gZC5EEiyZNJsafsC89qlaSA7BnmsDXVWQmc+s1feSYbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "13.5.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.2.tgz",
+      "integrity": "sha512-URSwhRYrbj/4MSBjLlefPTK3/tvg95TTm6mRaiZWBB6Za3hpHKi8vSdnCMw5D2aP6k0sQQIEG6Pzcfwm+C5vrg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "13.5.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.2.tgz",
+      "integrity": "sha512-HefiwAdIygFyNmyVsQeiJp+j8vPKpIRYDlmTlF9/tLdcd3qEL/UEBswa1M7cvO8nHcr27ZTKXz5m7dkd56/Esg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "13.5.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.2.tgz",
+      "integrity": "sha512-htGVVroW0tdHgMYwKWkxWvVoG2RlAdDXRO1RQxYDvOBQsaV0nZsgKkw0EJJJ3urTYnwKskn/MXm305cOgRxD2w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "13.5.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.2.tgz",
+      "integrity": "sha512-UBD333GxbHVGi7VDJPPDD1bKnx30gn2clifNJbla7vo5nmBV+x5adyARg05RiT9amIpda6yzAEEUu+s774ldkw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "13.5.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.2.tgz",
+      "integrity": "sha512-Em9ApaSFIQnWXRT3K6iFnr9uBXymixLc65Xw4eNt7glgH0eiXpg+QhjmgI2BFyc7k4ZIjglfukt9saNpEyolWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "13.5.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.2.tgz",
+      "integrity": "sha512-TBACBvvNYU+87X0yklSuAseqdpua8m/P79P0SG1fWUvWDDA14jASIg7kr86AuY5qix47nZLEJ5WWS0L20jAUNw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "13.5.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.2.tgz",
+      "integrity": "sha512-LfTHt+hTL8w7F9hnB3H4nRasCzLD/fP+h4/GUVBTxrkMJOnh/7OZ0XbYDKO/uuWwryJS9kZjhxcruBiYwc5UDw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -478,6 +623,15 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.2.tgz",
+      "integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/dotenv-flow": {
@@ -790,6 +944,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001538",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001538.tgz",
+      "integrity": "sha512-HWJnhnID+0YMtGlzcp3T9drmBJUVDchPJ08tpUGFLs9CYlwWPH2uLgpHn8fND5pCgXVtnGS3H4QR9XLMHVNkHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ]
+    },
     "node_modules/castable-video": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/castable-video/-/castable-video-0.5.2.tgz",
@@ -867,6 +1041,12 @@
       "engines": {
         "node": ">= 12"
       }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "dev": true
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -1368,6 +1548,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true
+    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -1838,10 +2024,75 @@
       "resolved": "https://registry.npmjs.org/mux-embed/-/mux-embed-4.28.1.tgz",
       "integrity": "sha512-fDJK0Dn3nSqRkLj5LUyjVmFGJt4cWq0/WFq75eP+PMF1cU3lemgKkBVYkTTzx3TUDTuebW+1LZ80r9OTcSa+wQ=="
     },
+    "node_modules/nanoid": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/napi-build-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
       "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
+    },
+    "node_modules/next": {
+      "version": "13.5.2",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.5.2.tgz",
+      "integrity": "sha512-vog4UhUaMYAzeqfiAAmgB/QWLW7p01/sg+2vn6bqc/CxHFYizMzLv6gjxKzl31EVFkfl/F+GbxlKizlkTE9RdA==",
+      "dev": true,
+      "dependencies": {
+        "@next/env": "13.5.2",
+        "@swc/helpers": "0.5.2",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001406",
+        "postcss": "8.4.14",
+        "styled-jsx": "5.1.1",
+        "watchpack": "2.4.0",
+        "zod": "3.21.4"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=16.14.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "13.5.2",
+        "@next/swc-darwin-x64": "13.5.2",
+        "@next/swc-linux-arm64-gnu": "13.5.2",
+        "@next/swc-linux-arm64-musl": "13.5.2",
+        "@next/swc-linux-x64-gnu": "13.5.2",
+        "@next/swc-linux-x64-musl": "13.5.2",
+        "@next/swc-win32-arm64-msvc": "13.5.2",
+        "@next/swc-win32-ia32-msvc": "13.5.2",
+        "@next/swc-win32-x64-msvc": "13.5.2"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
     },
     "node_modules/node-abi": {
       "version": "3.47.0",
@@ -1995,6 +2246,12 @@
         "node": "14 || >=16.14"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "license": "MIT",
@@ -2003,6 +2260,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+      "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.4",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prebuild-install": {
@@ -2419,6 +2700,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-support": {
       "version": "0.5.21",
       "dev": true,
@@ -2507,6 +2797,29 @@
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
+      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+      "dev": true,
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
       }
     },
     "node_modules/supports-color": {
@@ -2687,6 +3000,19 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
+    "node_modules/watchpack": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+      "dev": true,
+      "dependencies": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "4.0.0-beta.3",
       "license": "MIT",
@@ -2809,6 +3135,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,13 @@
       "require": "./dist/cjs/main.js",
       "default": "./dist/main.js"
     },
-    "./video-types/*": "./video-types/*.d.ts"
+    "./request-handler": {
+      "import": "./dist/request-handler.js",
+      "require": "./dist/cjs/request-handler.js",
+      "default": "./dist/request-handler.js"
+    },
+    "./video-types/*": "./video-types/*.d.ts",
+    "./dist/*": "./dist/*"
   },
   "scripts": {
     "clean": "rm -rf dist",
@@ -57,6 +63,7 @@
     "@types/react": "^18.2.16",
     "@types/yargs": "^17.0.24",
     "glob": "^10.3.3",
+    "next": "^13.5.2",
     "react": "^18.2.0",
     "tsx": "^3.12.7",
     "typescript": "^5.1.6"

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -1,5 +1,6 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import log from './logger.js';
+import { VIDEOS_DIR } from './constants.js';
 
 export interface Asset {
   status?: 'pending' | 'uploading' | 'processing' | 'ready' | 'error';
@@ -14,10 +15,6 @@ export interface Asset {
   updatedAt?: number;
 }
 
-function getAssetConfigPath(filePath: string) {
-  return `${filePath}.json`;
-}
-
 export async function getAsset(filePath: string): Promise<Asset | undefined> {
   const assetPath = getAssetConfigPath(filePath);
   const file = await readFile(assetPath);
@@ -26,7 +23,7 @@ export async function getAsset(filePath: string): Promise<Asset | undefined> {
   return asset;
 }
 
-export async function createAsset(filePath: string, assetDetails: Asset): Promise<Asset | undefined> {
+export async function createAsset(filePath: string, assetDetails?: Asset): Promise<Asset | undefined> {
   const assetPath = getAssetConfigPath(filePath);
 
   const newAssetDetails: Asset = {
@@ -70,4 +67,22 @@ export async function updateAsset(filePath: string, assetDetails: Asset): Promis
   await writeFile(assetPath, JSON.stringify(newAssetDetails));
 
   return newAssetDetails;
+}
+
+function getAssetConfigPath(filePath: string) {
+  if (isRemote(filePath)) {
+    // Add the asset directory and make remote url a safe file path.
+    return `${VIDEOS_DIR}/${toSafePath(filePath)}.json`;
+  }
+  return `${filePath}.json`
+}
+
+function isRemote(filePath: string) {
+  return /^https?:\/\//.test(filePath);
+}
+
+function toSafePath(str: string) {
+  return str
+    .replace(/^[^a-zA-Z0-9]+|[^a-zA-Z0-9]+$/g, '')
+    .replace(/[^a-zA-Z0-9._-]+/g, '_');
 }

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -3,7 +3,7 @@ import log from './logger.js';
 import { VIDEOS_DIR } from './constants.js';
 
 export interface Asset {
-  status?: 'pending' | 'uploading' | 'processing' | 'ready' | 'error';
+  status?: 'sourced' | 'pending' | 'uploading' | 'processing' | 'ready' | 'error';
   error?: any;
   originalFilePath?: string;
   size?: number;

--- a/src/cli/sync.ts
+++ b/src/cli/sync.ts
@@ -80,10 +80,6 @@ export async function handler(argv: Arguments) {
       const assetPath = path.join(parsedPath.dir, parsedPath.name);
       const existingAsset = await getAsset(assetPath);
 
-      // Ignore remote videos.
-      const originalFilePath = existingAsset?.originalFilePath;
-      if (originalFilePath && /^https?:\/\//.test(originalFilePath)) return;
-
       // If the existing asset is 'pending', 'uploading', or 'processing', run
       // it back through the local video handler.
       const assetStatus = existingAsset?.status;

--- a/src/cli/sync.ts
+++ b/src/cli/sync.ts
@@ -87,7 +87,7 @@ export async function handler(argv: Arguments) {
       // If the existing asset is 'pending', 'uploading', or 'processing', run
       // it back through the local video handler.
       const assetStatus = existingAsset?.status;
-      if (assetStatus && ['pending', 'uploading', 'processing'].includes(assetStatus)) {
+      if (assetStatus && ['sourced', 'pending', 'uploading', 'processing'].includes(assetStatus)) {
         return callHandler('local.video.added', existingAsset);
       }
     };

--- a/src/cli/sync.ts
+++ b/src/cli/sync.ts
@@ -80,6 +80,10 @@ export async function handler(argv: Arguments) {
       const assetPath = path.join(parsedPath.dir, parsedPath.name);
       const existingAsset = await getAsset(assetPath);
 
+      // Ignore remote videos.
+      const originalFilePath = existingAsset?.originalFilePath;
+      if (originalFilePath && /^https?:\/\//.test(originalFilePath)) return;
+
       // If the existing asset is 'pending', 'uploading', or 'processing', run
       // it back through the local video handler.
       const assetStatus = existingAsset?.status;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
 
-export const VIDEOS_PATH = path.join(process.cwd(), '/videos');
+export const VIDEOS_DIR = 'videos';
+export const VIDEOS_PATH = path.join(process.cwd(), VIDEOS_DIR);
 export const PACKAGE_NAME = '@mux/next-video';

--- a/src/handlers/api-request.ts
+++ b/src/handlers/api-request.ts
@@ -18,7 +18,7 @@ function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-export default async function handleRemoteVideoAdded(asset: Asset) {
+export default async function handleVideoAdded(asset: Asset) {
   if (!asset.originalFilePath) {
     log.error('No URL provided for asset.');
     console.error(asset);

--- a/src/handlers/api-request.ts
+++ b/src/handlers/api-request.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import Mux from '@mux/mux-node';
-import { fetch as uFetch } from 'undici';
 import { updateAsset, Asset } from '../assets.js';
 import log from '../logger.js';
 import { pollForAssetReady } from './local-upload.js';
@@ -12,10 +11,6 @@ let mux: Mux;
 // the instance.
 function initMux() {
   mux = new Mux();
-}
-
-function sleep(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export default async function handleVideoAdded(asset: Asset) {

--- a/src/handlers/local-upload.ts
+++ b/src/handlers/local-upload.ts
@@ -141,6 +141,28 @@ export default async function uploadLocalFile(asset: Asset) {
 
   const src = asset.originalFilePath;
 
+  // Imported remote videos can take an easy path.
+  if (src && /^https?:\/\//.test(src)) {
+
+    const assetObj = await mux.video.assets.create({
+      // @ts-ignore
+      input: [{ url: src }],
+      playback_policy: ['public']
+    });
+
+    log.info(log.label('Asset is processing:'), src);
+    log.space(chalk.gray('>'), log.label('Mux Asset ID:'), assetObj.id);
+
+    const processingAsset = await updateAsset(src, {
+      status: 'processing',
+      externalIds: {
+        assetId: assetObj.id,
+      },
+    });
+
+    return pollForAssetReady(src, processingAsset);
+  }
+
   let upload: Mux.Video.Uploads.Upload;
   try {
     // Create a direct upload url

--- a/src/handlers/local-upload.ts
+++ b/src/handlers/local-upload.ts
@@ -26,7 +26,7 @@ function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function pollForAssetReady(filePath: string, asset: Asset) {
+export async function pollForAssetReady(filePath: string, asset: Asset) {
   if (!asset.externalIds?.assetId) {
     log.error('No assetId provided for asset.');
     console.error(asset);
@@ -197,7 +197,7 @@ export default async function uploadLocalFile(asset: Asset) {
   return pollForUploadAsset(src, processingAsset);
 }
 
-async function createThumbHash(imgUrl: string) {
+export async function createThumbHash(imgUrl: string) {
   const response = await uFetch(imgUrl);
   const buffer = await response.arrayBuffer();
 

--- a/src/handlers/remote-request.ts
+++ b/src/handlers/remote-request.ts
@@ -1,0 +1,58 @@
+import chalk from 'chalk';
+import Mux from '@mux/mux-node';
+import { fetch as uFetch } from 'undici';
+import { updateAsset, Asset } from '../assets.js';
+import log from '../logger.js';
+import { pollForAssetReady } from './local-upload.js';
+
+let mux: Mux;
+
+// We don't want to blow things up immediately if Mux isn't configured, but we also don't want to
+// need to initialize it every time in situations like polling. So we'll initialize it lazily but cache
+// the instance.
+function initMux() {
+  mux = new Mux();
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export default async function handleRemoteVideoAdded(asset: Asset) {
+  if (!asset.originalFilePath) {
+    log.error('No URL provided for asset.');
+    console.error(asset);
+    return;
+  }
+
+  initMux();
+
+  if (asset.status === 'ready') {
+    return;
+  } else if (asset.status === 'processing') {
+    log.info(log.label('Asset is already processing. Polling for completion:'), asset.originalFilePath);
+    return pollForAssetReady(asset.originalFilePath, asset);
+  }
+
+  const src = asset.originalFilePath;
+
+  const assetObj = await mux.video.assets.create({
+    // @ts-ignore
+    input: [{
+      url: asset.originalFilePath
+    }],
+    playback_policy: ['public']
+  });
+
+  log.info(log.label('Asset is processing:'), src);
+  log.space(chalk.gray('>'), log.label('Mux Asset ID:'), assetObj.id);
+
+  const processingAsset = await updateAsset(src, {
+    status: 'processing',
+    externalIds: {
+      assetId: assetObj.id,
+    },
+  });
+
+  return pollForAssetReady(src, processingAsset);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,18 +1,20 @@
 import videoHandler, { callHandler } from './video-handler.js';
 import localUploadHandler from './handlers/local-upload.js';
+import remoteRequestHandler from './handlers/remote-request.js';
 import log from './logger.js';
+import withNextVideo from './with-next-video.js';
 
 try {
   // Don't love this little race condition... we gotta figure that one out.
   // Basically we need to make sure all the handlers are registered before we start watching for files.
   videoHandler('local.video.added', localUploadHandler);
+  videoHandler('remote.video.added', remoteRequestHandler);
+
 } catch (err) {
   // We'd much prefer to log an error here than crash since it can put
   // the main Next process in a weird state.
   log.error('An exception occurred within next-video. You may need to restart your dev server.');
   console.error(err);
 }
-
-import withNextVideo from './with-next-video.js';
 
 export { videoHandler, withNextVideo, callHandler };

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import videoHandler, { callHandler } from './video-handler.js';
 import localUploadHandler from './handlers/local-upload.js';
-import remoteRequestHandler from './handlers/remote-request.js';
+import apiRequestHandler from './handlers/api-request.js';
 import log from './logger.js';
 import withNextVideo from './with-next-video.js';
 
@@ -8,7 +8,7 @@ try {
   // Don't love this little race condition... we gotta figure that one out.
   // Basically we need to make sure all the handlers are registered before we start watching for files.
   videoHandler('local.video.added', localUploadHandler);
-  videoHandler('remote.video.added', remoteRequestHandler);
+  videoHandler('request.video.added', apiRequestHandler);
 
 } catch (err) {
   // We'd much prefer to log an error here than crash since it can put

--- a/src/next-video.tsx
+++ b/src/next-video.tsx
@@ -127,7 +127,7 @@ export default function NextVideo(props: NextVideoProps) {
         }
       </MuxPlayer>
       {DEV_MODE && <Alert
-        hidden={Boolean(playing || (status && status === 'ready'))}
+        hidden={Boolean(playing || !status || status === 'ready')}
         status={status}
       />}
     </div>

--- a/src/next-video.tsx
+++ b/src/next-video.tsx
@@ -88,6 +88,8 @@ export default function NextVideo(props: NextVideoProps) {
   }
 
   async function fetchItems(abortSignal: AbortSignal) {
+    if (typeof asset === 'object') return;
+
     try {
       const requestUrl = new URL(API_ROUTE, window.location.href);
       requestUrl.searchParams.set('url', asset as string);
@@ -107,7 +109,7 @@ export default function NextVideo(props: NextVideoProps) {
     }
   }
 
-  const needsPolling = typeof asset === 'string' || status != 'ready';
+  const needsPolling = DEV_MODE && (typeof asset === 'string' || status != 'ready');
   usePolling(fetchItems, needsPolling ? 1000 : null);
 
   const [playing, setPlaying] = useState(false);

--- a/src/next-video.tsx
+++ b/src/next-video.tsx
@@ -29,9 +29,10 @@ interface NextVideoProps extends Omit<MuxPlayerProps, 'src'> {
 }
 
 const DEV_MODE = process.env.NODE_ENV === 'development';
-const FILES_FOLDER = /^videos\//;
+const FILES_FOLDER = 'videos/';
 
 const toSymlinkPath = (path?: string) => {
+  if (!path?.startsWith(FILES_FOLDER)) return path;
   return path?.replace(FILES_FOLDER, `_${FILES_FOLDER}`);
 }
 

--- a/src/next-video.tsx
+++ b/src/next-video.tsx
@@ -4,7 +4,7 @@
 import { useState } from 'react';
 import MuxPlayer from '@mux/mux-player-react';
 import type { MuxPlayerProps } from '@mux/mux-player-react';
-import { Asset } from './assets.js';
+import type { Asset } from './assets.js';
 
 declare module 'react' {
   interface CSSProperties {
@@ -177,7 +177,7 @@ function Alert({ status, hidden }: AlertProps) {
       title = 'Error';
       message = 'An error occurred while uploading your video. Please check the CLI logs for more info.';
       break;
-    case 'source':
+    case 'sourced':
       title = 'Video is not processing';
       message = 'Make sure to run next-video sync. The currently loaded video is the source file.';
       break;

--- a/src/request-handler.ts
+++ b/src/request-handler.ts
@@ -26,7 +26,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   } catch {
     // todo: does this require auth?
     asset = await createAsset(url);
-    await callHandler('request.video.added', asset);
+
+    if (asset) {
+      await callHandler('request.video.added', asset);
+    }
 
     res.status(200).json(asset);
     return;

--- a/src/request-handler.ts
+++ b/src/request-handler.ts
@@ -26,7 +26,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   } catch {
     // todo: does this require auth?
     asset = await createAsset(url);
-    await callHandler('remote.video.added', asset);
+    await callHandler('request.video.added', asset);
 
     res.status(200).json(asset);
     return;

--- a/src/request-handler.ts
+++ b/src/request-handler.ts
@@ -1,0 +1,36 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { callHandler } from './main.js';
+import { createAsset, getAsset } from './assets.js';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+
+  const url = String(req.query.url);
+  if (!url) {
+    res.status(400).json({ error: 'url parameter is required' });
+    return;
+  }
+
+  const remoteRegex = /^https?:\/\//;
+  const isRemote = remoteRegex.test(url);
+
+  if (!isRemote) {
+    // todo: handle local files via string src
+    res.status(400).json({ error: 'local files should be imported as a module' });
+    return;
+  }
+
+  let asset;
+  try {
+    asset = await getAsset(url);
+  } catch {
+    // todo: does this require auth?
+    asset = await createAsset(url);
+    await callHandler('remote.video.added', asset);
+
+    res.status(200).json(asset);
+    return;
+  }
+
+  res.status(200).json(asset);
+}

--- a/src/request-handler.ts
+++ b/src/request-handler.ts
@@ -3,12 +3,27 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { callHandler } from './main.js';
 import { createAsset, getAsset } from './assets.js';
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+// App Router
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const url = searchParams.get('url');
+  const { status, data } = await handleRequest(url);
+  // @ts-ignore - Response.json() is only valid from TypeScript 5.2
+  return Response.json(data, { status });
+}
 
-  const url = String(req.query.url);
+// Pages Router
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { status, data } = await handleRequest(String(req.query.url));
+  res.status(status).json(data);
+}
+
+async function handleRequest(url?: string | null) {
   if (!url) {
-    res.status(400).json({ error: 'url parameter is required' });
-    return;
+    return {
+      status: 400,
+      data: { error: 'url parameter is required' }
+    };
   }
 
   const remoteRegex = /^https?:\/\//;
@@ -16,8 +31,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   if (!isRemote) {
     // todo: handle local files via string src
-    res.status(400).json({ error: 'local files should be imported as a module' });
-    return;
+    return {
+      status: 400,
+      data: { error: 'local files should be imported as a module' }
+    };
   }
 
   let asset;
@@ -31,9 +48,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       await callHandler('request.video.added', asset);
     }
 
-    res.status(200).json(asset);
-    return;
+    return { status: 200, data: asset };
   }
 
-  res.status(200).json(asset);
+  return { status: 200, data: asset };
 }

--- a/src/webpack-loader.ts
+++ b/src/webpack-loader.ts
@@ -1,24 +1,49 @@
 import path from 'node:path';
-import { readFile } from 'node:fs/promises';
+import { readFile, writeFile } from 'node:fs/promises';
+
+import { VIDEOS_DIR } from './constants.js';
 
 export default async function loader(this: any, source: any) {
-  var jsonPath = path.resolve(this.resourcePath + '.json');
 
-  this.addDependency(jsonPath);
+  const assetPath = path.resolve(getAssetConfigPath(this.resourcePath));
 
-  let vid;
+  this.addDependency(assetPath);
+
+  let asset;
 
   try {
-    vid = await readFile(jsonPath, 'utf-8');
+    asset = await readFile(assetPath, 'utf-8');
   } catch {
 
-    const originalFilePath = path.relative(process.cwd(), this.resourcePath);
+    const originalFilePath = isRemote(this.resourcePath)
+      ? this.resourcePath
+      : path.relative(process.cwd(), this.resourcePath);
 
-    vid = JSON.stringify({
-      status: 'source',
+    asset = JSON.stringify({
+      status: 'sourced',
       originalFilePath
-    })
+    });
+
+    await writeFile(assetPath, asset, { flag: 'wx' });
   }
 
-  return `export default ${vid}`;
+  return `export default ${asset}`;
+}
+
+function getAssetConfigPath(filePath: string) {
+  if (isRemote(filePath)) {
+    // Add the asset directory and make remote url a safe file path.
+    return `${VIDEOS_DIR}/${toSafePath(filePath)}.json`;
+  }
+  return `${filePath}.json`
+}
+
+function isRemote(filePath: string) {
+  return /^https?:\/\//.test(filePath);
+}
+
+function toSafePath(str: string) {
+  return str
+    .replace(/^[^a-zA-Z0-9]+|[^a-zA-Z0-9]+$/g, '')
+    .replace(/[^a-zA-Z0-9._-]+/g, '_');
 }

--- a/src/with-next-video.ts
+++ b/src/with-next-video.ts
@@ -32,6 +32,16 @@ export default async function withNextVideo(nextConfig: any) {
         );
       }
 
+      if (Array.isArray(config.externals)) {
+        config.externals.unshift({
+          sharp: 'commonjs sharp'
+        });
+      } else {
+        config.externals = Object.assign({}, {
+          sharp: 'commonjs sharp'
+        }, config.externals);
+      }
+
       config.module.rules.push({
         test: /\.(mp4|webm|mkv|ogg|ogv|wmv|avi|mov|flv|m4v|3gp)$/,
         use: [

--- a/src/with-next-video.ts
+++ b/src/with-next-video.ts
@@ -42,6 +42,16 @@ export default async function withNextVideo(nextConfig: any) {
         }, config.externals);
       }
 
+      config.experiments.buildHttp = {
+        allowedUris: [
+          /https?:\/\/.*\.(mp4|webm|mkv|ogg|ogv|wmv|avi|mov|flv|m4v|3gp)$/,
+          ...(config.experiments.buildHttp?.allowedUris ?? [])
+        ],
+        ...(config.experiments.buildHttp || {}),
+        // Disable cache to prevent Webpack from downloading the remote sources.
+        cacheLocation: false,
+      }
+
       config.module.rules.push({
         test: /\.(mp4|webm|mkv|ogg|ogv|wmv|avi|mov|flv|m4v|3gp)$/,
         use: [


### PR DESCRIPTION
This PR adds support for creating a Mux clip from a remote source url.
A Next.js API is required in the web app to handle the `/api/video` route.

```js
// pages/api/video/[[...handler]].ts
export { default } from '@mux/next-video/request-handler'
```

```js
// app/page.tsx
import Video from '@mux/next-video';

export default function Home() {
  return <Video style={{ width: 640, aspectRatio: 2.4 }} src="https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/high.mp4" />;
}
```

saved in 

```json
// videos/https_stream.mux.com_A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg_high.mp4.json
{
  "status":"ready",  
  "originalFilePath": "https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/high.mp4", 
  "externalIds":{"assetId":"0102502PiOVxFuSEdNESe7m00wrs00XBARJWZRBlFdTUcGxg","playbackId":"ohIr601A4CISlBV87dZZCfdL4yzvdgzlikajrvSjk8Hc"}, 
  "createdAt": 1695323804937, 
  "updatedAt": 1695323810259, 
  "blurDataURL": 
  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAOCAYAAABO3B6yAAAHWklEQVR4AQC..."
}
```