### PR TITLE
feat: add video config

### DIFF
--- a/src/assets.ts
+++ b/src/assets.ts
@@ -1,6 +1,6 @@
+import { env } from 'node:process';
 import { readFile, writeFile } from 'node:fs/promises';
 import log from './logger.js';
-import { VIDEOS_DIR } from './constants.js';
 
 export interface Asset {
   status?: 'sourced' | 'pending' | 'uploading' | 'processing' | 'ready' | 'error';
@@ -71,6 +71,9 @@ export async function updateAsset(filePath: string, assetDetails: Asset): Promis
 
 function getAssetConfigPath(filePath: string) {
   if (isRemote(filePath)) {
+    const VIDEOS_DIR = JSON.parse(env['__NEXT_VIDEO_OPTS'] ?? '{}').folder;
+    if (!VIDEOS_DIR) throw new Error('Missing video `folder` config.');
+
     // Add the asset directory and make remote url a safe file path.
     return `${VIDEOS_DIR}/${toSafePath(filePath)}.json`;
   }

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -218,7 +218,7 @@ export async function handler(argv: Arguments) {
   }
 
   try {
-    const update = await updateNextConfigFile();
+    const update = await updateNextConfigFile('./', { folder: baseDir });
 
     if (update) {
       changes.push([log.add, `Updated ${update.configPath} to include next-video.`]);

--- a/src/cli/lib/next-config.ts
+++ b/src/cli/lib/next-config.ts
@@ -1,21 +1,11 @@
-import { builders, loadFile, generateCode, writeFile } from 'magicast';
+import { builders, parseModule, loadFile, generateCode, writeFile } from 'magicast';
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
 import { PACKAGE_NAME } from '../../constants.js';
-
-const COMMON_TEMPLATE = `
-
-// Everything below here added by the ${PACKAGE_NAME} CLI wizard.
-// Feel free to clean this up!
-
-const originalConfig = module.exports;
-
-const { withNextVideo } = require('${path.join(PACKAGE_NAME, 'process')}');
-
-module.exports = withNextVideo(originalConfig);
-`;
+import { videoConfigDefault } from '../../config.js';
+import type { VideoConfig } from '../../config.js';
 
 function extensionToType(filePath: string) {
   if (filePath.endsWith('.mjs')) {
@@ -25,7 +15,7 @@ function extensionToType(filePath: string) {
   return 'commonjs';
 }
 
-export default async function updateNextConfigFile(parentDir: string = './') {
+export default async function updateNextConfigFile(parentDir: string = './', videoConfig?: VideoConfig) {
   let type: 'module' | 'commonjs' = 'commonjs';
   let configPath: string | undefined = undefined;
   let configContents: string = '';
@@ -59,7 +49,36 @@ export default async function updateNextConfigFile(parentDir: string = './') {
   }
 
   if (type === 'commonjs') {
-    await fs.appendFile(configPath, COMMON_TEMPLATE);
+    const mod = parseModule(configContents);
+
+    // @ts-ignore
+    const body = mod?.$ast?.body
+    // Iterate from bottom to top.
+    let i = body.length ?? 0;
+    while (i--) {
+      const node = body[i];
+      // Replace `module.exports = something;` with `module.exports = withNextVideo(something);`
+      if (node.type === 'ExpressionStatement' && node.expression.type === 'AssignmentExpression') {
+        const { left, right } = node.expression ?? {};
+        if (left.type === 'MemberExpression' && left.object.type === 'Identifier' && left.object.name === 'module') {
+          if (left.property.type === 'Identifier' && left.property.name === 'exports') {
+            if (right.type === 'Identifier') {
+              const expressionToWrap = generateCode(right).code;
+              node.expression.right = wrapWithNextVideo(expressionToWrap, videoConfig).$ast;
+            }
+          }
+        }
+      }
+    }
+
+    let code =
+`const { withNextVideo } = require('${path.join(PACKAGE_NAME, 'process')}')
+
+${generateCode(mod).code}
+`;
+
+    // @ts-ignore
+    await fs.writeFile(configPath, code);
 
     return { type, configPath };
   }
@@ -74,11 +93,19 @@ export default async function updateNextConfigFile(parentDir: string = './') {
     });
 
     const expressionToWrap = generateCode(mod.exports.default.$ast).code;
-    mod.exports.default = builders.raw(`withNextVideo(${expressionToWrap})`);
+    mod.exports.default = wrapWithNextVideo(expressionToWrap, videoConfig);
 
     // @ts-ignore
     writeFile(mod, configPath);
 
     return { type, configPath };
+  }
+}
+
+function wrapWithNextVideo(expressionToWrap: string, videoConfig?: VideoConfig) {
+  if (videoConfig?.folder && videoConfig.folder !== videoConfigDefault.folder) {
+    return builders.raw(`withNextVideo(${expressionToWrap}, { folder: '${videoConfig.folder}' })`);
+  } else {
+    return builders.raw(`withNextVideo(${expressionToWrap})`);
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,18 @@
+/**
+ * Video configurations
+ */
+export type VideoConfigComplete = {
+
+  /** The folder in your project where you will put all video source files. */
+  folder: string;
+
+  /** The route of the video API request for string video source URLs. */
+  path: string
+}
+
+export type VideoConfig = Partial<VideoConfigComplete>;
+
+export const videoConfigDefault: VideoConfigComplete = {
+  folder: 'videos',
+  path: '/api/video',
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,1 @@
-import path from 'node:path';
-
-export const VIDEOS_DIR = 'videos';
-export const VIDEOS_PATH = path.join(process.cwd(), VIDEOS_DIR);
 export const PACKAGE_NAME = 'next-video';

--- a/src/webpack-loader.ts
+++ b/src/webpack-loader.ts
@@ -1,10 +1,8 @@
 import path from 'node:path';
 import { readFile, writeFile } from 'node:fs/promises';
-
-import { VIDEOS_DIR } from './constants.js';
+import { env } from 'node:process';
 
 export default async function loader(this: any, source: any) {
-
   const assetPath = path.resolve(getAssetConfigPath(this.resourcePath));
 
   this.addDependency(assetPath);
@@ -32,6 +30,9 @@ export default async function loader(this: any, source: any) {
 
 function getAssetConfigPath(filePath: string) {
   if (isRemote(filePath)) {
+    const VIDEOS_DIR = JSON.parse(env['__NEXT_VIDEO_OPTS'] ?? '{}').folder;
+    if (!VIDEOS_DIR) throw new Error('Missing video `folder` config.');
+
     // Add the asset directory and make remote url a safe file path.
     return `${VIDEOS_DIR}/${toSafePath(filePath)}.json`;
   }


### PR DESCRIPTION
Adds a `path` and `folder` video config that can be added in next.config.js

the path naming is also used by `next/image` for the API endpoint `_next/image`

```js
const { withNextVideo } = require('next-video/process')

/** @type {import('next').NextConfig} */
const nextConfig = {}

module.exports = withNextVideo(nextConfig, { folder: 'myvids' })
```
