### PR TITLE
feat: support custom player & tidy up

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,14 +155,14 @@ That can be solved by creating a new API endpoint in your Next.js app for `/api/
 
 ```js
 // app/api/video/route.js
-export { GET } from 'next-video/request-handler'
+export { GET } from 'next-video/request-handler';
 ```
 
 **Pages router (Next.js)**
 
 ```js
 // pages/api/video/[[...handler]].js
-export { default } from 'next-video/request-handler'
+export { default } from 'next-video/request-handler';
 ```
 
 Then set the `src` attribute to the URL of the remote video, refresh the page and the video will start processing.
@@ -172,6 +172,39 @@ import Video from 'next-video';
 
 export default function Page() {
   return <Video src="https://www.mydomain.com/remote-video.mp4" />;
+}
+```
+
+### Custom Player
+
+You can customize the player by passing a custom player component to the `as` prop.  
+The custom player component accepts the following props:
+
+- `asset`: The asset that is processed, contains useful asset metadata and upload status.
+- `src`: A string video source URL if the asset is ready.
+- `poster`: A string image source URL if the asset is ready.
+- `blurDataURL`: A string base64 image source URL that can be used as a placeholder.
+
+
+```tsx
+import Video from 'next-video';
+import { ReactPlayerAsVideo } from './player';
+import awesomeVideo from '/videos/awesome-video.mp4';
+
+export default function Page() {
+  return <Video as={ReactPlayerAsVideo} src={awesomeVideo} />;
+}
+```
+
+```tsx
+// player.js
+import ReactPlayer from 'react-player';
+
+export function ReactPlayerAsVideo(props) {
+  let { asset, src, poster, blurDataURL, ...rest } = props;
+  let config = { file: { attributes: { poster } } };
+
+  return <ReactPlayer url={src} config={config} {...rest} />;
 }
 ```
 

--- a/src/components/default-player.ts
+++ b/src/components/default-player.ts
@@ -1,6 +1,0 @@
-export { default } from '@mux/mux-player-react';
-export * from '@mux/mux-player-react';
-export type {
-  MuxPlayerProps as DefaultPlayerProps,
-  MuxPlayerRefAttributes as DefaultPlayerRefAttributes,
-} from '@mux/mux-player-react';

--- a/src/components/default-player.ts
+++ b/src/components/default-player.ts
@@ -1,0 +1,6 @@
+export { default } from '@mux/mux-player-react';
+export * from '@mux/mux-player-react';
+export type {
+  MuxPlayerProps as DefaultPlayerProps,
+  MuxPlayerRefAttributes as DefaultPlayerRefAttributes,
+} from '@mux/mux-player-react';

--- a/src/components/default-player.tsx
+++ b/src/components/default-player.tsx
@@ -1,0 +1,78 @@
+import { forwardRef } from 'react';
+import MuxPlayer from '@mux/mux-player-react';
+import { getPosterURLFromPlaybackId } from './utils.js';
+
+import type { MuxPlayerProps, MuxPlayerRefAttributes } from '@mux/mux-player-react';
+import type { PlayerProps } from './types.js';
+
+export * from '@mux/mux-player-react';
+
+export type DefaultPlayerRefAttributes = MuxPlayerRefAttributes;
+
+export type DefaultPlayerProps = Omit<MuxPlayerProps, 'src'> & PlayerProps;
+
+export const DefaultPlayer = forwardRef<DefaultPlayerRefAttributes | null, DefaultPlayerProps>((allProps: DefaultPlayerProps, forwardedRef) => {
+  let {
+    style,
+    children,
+    status,
+    controls,
+    poster,
+    blurDataURL,
+    src,
+    ...rest
+  } = allProps;
+
+  let props: MuxPlayerProps = rest;
+  let srcSet: string | undefined;
+
+  if (typeof src === 'string') {
+    props.src = src;
+  }
+  else if (typeof src === 'object') {
+
+    const playbackId = src.externalIds?.playbackId;
+
+    if (src.status === 'ready' && playbackId) {
+
+      props.playbackId = playbackId;
+
+      if (!poster) {
+        poster = getPosterURLFromPlaybackId(playbackId, props);
+        srcSet =
+          `${getPosterURLFromPlaybackId(playbackId, { ...props, width: 480 })} 480w,` +
+          `${getPosterURLFromPlaybackId(playbackId, { ...props, width: 640 })} 640w,` +
+          `${getPosterURLFromPlaybackId(playbackId, { ...props, width: 960 })} 960w,` +
+          `${getPosterURLFromPlaybackId(playbackId, { ...props, width: 1280 })} 1280w,` +
+          `${getPosterURLFromPlaybackId(playbackId, { ...props, width: 1600 })} 1600w,` +
+          `${poster} 1920w`;
+      }
+    }
+  }
+
+  // The Mux player supports a poster image slot which improves the loading speed.
+  if (poster) {
+    poster = '';
+    children = <>
+      {children}
+      <img
+        slot="poster"
+        srcSet={srcSet}
+        style={{ backgroundImage: blurDataURL ? `url('${blurDataURL}')` : undefined }}
+      />
+    </>
+  }
+
+  return (
+    <MuxPlayer
+      ref={forwardedRef}
+      style={{
+        '--controls': controls === false ? 'none' : undefined,
+        ...style,
+      }}
+      children={children}
+      poster={poster}
+      {...props}
+    />
+  );
+});

--- a/src/components/default-player.tsx
+++ b/src/components/default-player.tsx
@@ -15,38 +15,29 @@ export const DefaultPlayer = forwardRef<DefaultPlayerRefAttributes | null, Defau
   let {
     style,
     children,
-    status,
+    asset,
     controls,
     poster,
     blurDataURL,
-    src,
     ...rest
   } = allProps;
 
   let props: MuxPlayerProps = rest;
   let srcSet: string | undefined;
+  const playbackId = asset?.externalIds?.playbackId;
 
-  if (typeof src === 'string') {
-    props.src = src;
-  }
-  else if (typeof src === 'object') {
+  if (playbackId && asset?.status === 'ready') {
+    props.src = null;
+    props.playbackId = playbackId;
 
-    const playbackId = src.externalIds?.playbackId;
-
-    if (src.status === 'ready' && playbackId) {
-
-      props.playbackId = playbackId;
-
-      if (!poster) {
-        poster = getPosterURLFromPlaybackId(playbackId, props);
-        srcSet =
-          `${getPosterURLFromPlaybackId(playbackId, { ...props, width: 480 })} 480w,` +
-          `${getPosterURLFromPlaybackId(playbackId, { ...props, width: 640 })} 640w,` +
-          `${getPosterURLFromPlaybackId(playbackId, { ...props, width: 960 })} 960w,` +
-          `${getPosterURLFromPlaybackId(playbackId, { ...props, width: 1280 })} 1280w,` +
-          `${getPosterURLFromPlaybackId(playbackId, { ...props, width: 1600 })} 1600w,` +
-          `${poster} 1920w`;
-      }
+    if (poster) {
+      srcSet =
+        `${getPosterURLFromPlaybackId(playbackId, { ...props, width: 480 })} 480w,` +
+        `${getPosterURLFromPlaybackId(playbackId, { ...props, width: 640 })} 640w,` +
+        `${getPosterURLFromPlaybackId(playbackId, { ...props, width: 960 })} 960w,` +
+        `${getPosterURLFromPlaybackId(playbackId, { ...props, width: 1280 })} 1280w,` +
+        `${getPosterURLFromPlaybackId(playbackId, { ...props, width: 1600 })} 1600w,` +
+        `${poster} 1920w`;
     }
   }
 

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -40,7 +40,7 @@ export interface VideoProps extends Omit<DefaultPlayerProps, 'src'> {
    * Can be a local or remote video file.
    * If it's a string be sure to create an API endpoint to handle the request.
    */
-  src: Asset | string;
+  src?: Asset | string;
 
   /**
    * Give a fixed width to the video.
@@ -78,16 +78,14 @@ export interface VideoProps extends Omit<DefaultPlayerProps, 'src'> {
 
 export interface PlayerProps {
   /**
-   * The status of the asset that is processed.
+   * The asset object for the video.
    */
-  status?: Asset['status'];
+  asset?: Asset;
 
   /**
-   * An imported video source object or a string video source URL.
-   * Can be a local or remote video file.
-   * If it's a string be sure to create an API endpoint to handle the request.
+   * A string video source URL.
    */
-  src?: Asset | string;
+  src?: string | undefined;
 
   /**
    * Set to false to hide the video controls.

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -9,6 +9,26 @@ declare module 'react' {
   }
 }
 
+export type VideoLoader = (p: VideoLoaderProps) => Promise<string>;
+export type VideoLoaderWithConfig = (p: VideoLoaderPropsWithConfig) => Promise<string>;
+
+export interface VideoLoaderProps {
+  src: string;
+  width?: number;
+  height?: number;
+}
+
+export type VideoLoaderPropsWithConfig = VideoLoaderProps & {
+  config: Readonly<VideoConfig>
+}
+
+export interface PosterProps {
+  token?: string;
+  thumbnailTime?: number;
+  width?: number;
+  domain?: string;
+}
+
 export interface VideoProps extends Omit<DefaultPlayerProps, 'src'> {
   /**
    * The component type to render the video as.
@@ -56,22 +76,27 @@ export interface VideoProps extends Omit<DefaultPlayerProps, 'src'> {
   loader?: VideoLoader;
 }
 
-export type VideoLoader = (p: VideoLoaderProps) => Promise<string>;
-export type VideoLoaderWithConfig = (p: VideoLoaderPropsWithConfig) => Promise<string>;
+export interface PlayerProps {
+  /**
+   * The status of the asset that is processed.
+   */
+  status?: Asset['status'];
 
-export interface VideoLoaderProps {
-  src: string;
-  width?: number;
-  height?: number;
-}
+  /**
+   * An imported video source object or a string video source URL.
+   * Can be a local or remote video file.
+   * If it's a string be sure to create an API endpoint to handle the request.
+   */
+  src?: Asset | string;
 
-export type VideoLoaderPropsWithConfig = VideoLoaderProps & {
-  config: Readonly<VideoConfig>
-}
+  /**
+   * Set to false to hide the video controls.
+   */
+  controls?: boolean;
 
-export interface PosterProps {
-  token?: string;
-  thumbnailTime?: number;
-  width?: number;
-  domain?: string;
+  /**
+   * Set a manual data URL to be used as a placeholder image before the poster image successfully loads.
+   * For imported videos this will be automatically generated.
+   */
+  blurDataURL?: string;
 }

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -1,0 +1,77 @@
+import type { VideoConfig } from '../config.js';
+import type { FunctionComponent } from 'react';
+import type { DefaultPlayerProps } from './default-player.js';
+import type { Asset } from '../assets.js';
+
+declare module 'react' {
+  interface CSSProperties {
+    [key: `--${string}`]: any;
+  }
+}
+
+export interface VideoProps extends Omit<DefaultPlayerProps, 'src'> {
+  /**
+   * The component type to render the video as.
+   */
+  as: FunctionComponent<DefaultPlayerProps>;
+
+  /**
+   * An imported video source object or a string video source URL.
+   * Can be a local or remote video file.
+   * If it's a string be sure to create an API endpoint to handle the request.
+   */
+  src: Asset | string;
+
+  /**
+   * Give a fixed width to the video.
+   */
+  width?: number;
+
+  /**
+   * Give a fixed height to the video.
+   */
+  height?: number;
+
+  /**
+   * Set to false to hide the video controls.
+   */
+  controls?: boolean;
+
+  /**
+   * Set a manual data URL to be used as a placeholder image before the poster image successfully loads.
+   * For imported videos this will be automatically generated.
+   */
+  blurDataURL?: string;
+
+  /**
+   * For best image loading performance the user should provide the sizes attribute.
+   * The width of the image in the webpage. e.g. sizes="800px". Defaults to 100vw.
+   * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#sizes
+   */
+  sizes?: string;
+
+  /**
+   * A custom function used to resolve video URLs.
+   */
+  loader?: VideoLoader;
+}
+
+export type VideoLoader = (p: VideoLoaderProps) => Promise<string>;
+export type VideoLoaderWithConfig = (p: VideoLoaderPropsWithConfig) => Promise<string>;
+
+export interface VideoLoaderProps {
+  src: string;
+  width?: number;
+  height?: number;
+}
+
+export type VideoLoaderPropsWithConfig = VideoLoaderProps & {
+  config: Readonly<VideoConfig>
+}
+
+export interface PosterProps {
+  token?: string;
+  thumbnailTime?: number;
+  width?: number;
+  domain?: string;
+}

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -1,66 +1,20 @@
 import { useEffect, useRef, useCallback } from 'react';
+import type { PosterProps } from './types';
+
+export const config = JSON.parse(
+  process.env.NEXT_PUBLIC_DEV_VIDEO_OPTS
+  ?? process.env.NEXT_PUBLIC_VIDEO_OPTS
+  ?? '{}'
+);
 
 const MUX_VIDEO_DOMAIN = 'mux.com';
-
-interface PosterProps {
-  token?: string;
-  thumbnailTime?: number;
-  width?: number;
-  domain?: string;
-}
-
-export const getPosterURLFromPlaybackId = (
-  playbackId?: string,
-  { token, thumbnailTime, width, domain = MUX_VIDEO_DOMAIN }: PosterProps = {}
-) => {
-  // NOTE: thumbnailTime is not supported when using a signedURL/token. Remove under these cases. (CJP)
-  const time = token == null ? thumbnailTime : undefined;
-
-  const { aud } = parseJwt(token);
-
-  if (token && aud !== 't') {
-    return;
-  }
-
-  return `https://image.${domain}/${playbackId}/thumbnail.webp${toQuery({
-    token,
-    time,
-    width,
-  })}`;
-};
-
-function toQuery(obj: Record<string, any>) {
-  const params = toParams(obj).toString();
-  return params ? '?' + params : '';
-}
-
-function toParams(obj: Record<string, any>) {
-  const params: Record<string, any> = {};
-  for (const key in obj) {
-    if (obj[key] != null) params[key] = obj[key];
-  }
-  return new URLSearchParams(params);
-}
-
-function parseJwt(token: string | undefined) {
-  const base64Url = (token ?? '').split('.')[1];
-
-  // exit early on invalid value
-  if (!base64Url) return {};
-
-  const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
-  const jsonPayload = decodeURIComponent(
-    atob(base64)
-      .split('')
-      .map(function (c) {
-        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
-      })
-      .join('')
-  );
-  return JSON.parse(jsonPayload);
-}
-
 const DEFAULT_POLLING_INTERVAL = 5000;
+const FILES_FOLDER = `${config.folder ?? 'videos'}/`;
+
+export const toSymlinkPath = (path?: string) => {
+  if (!path?.startsWith(FILES_FOLDER)) return path;
+  return path?.replace(FILES_FOLDER, `_${FILES_FOLDER}`);
+}
 
 // Note: doesn't get updated when the callback function changes
 export function usePolling(
@@ -112,4 +66,55 @@ export function useInterval(callback: () => any, delay: number | null) {
       return () => clearTimeout(id);
     }
   }, [delay]);
+}
+
+export const getPosterURLFromPlaybackId = (
+  playbackId?: string,
+  { token, thumbnailTime, width, domain = MUX_VIDEO_DOMAIN }: PosterProps = {}
+) => {
+  // NOTE: thumbnailTime is not supported when using a signedURL/token. Remove under these cases. (CJP)
+  const time = token == null ? thumbnailTime : undefined;
+
+  const { aud } = parseJwt(token);
+
+  if (token && aud !== 't') {
+    return;
+  }
+
+  return `https://image.${domain}/${playbackId}/thumbnail.webp${toQuery({
+    token,
+    time,
+    width,
+  })}`;
+};
+
+function toQuery(obj: Record<string, any>) {
+  const params = toParams(obj).toString();
+  return params ? '?' + params : '';
+}
+
+function toParams(obj: Record<string, any>) {
+  const params: Record<string, any> = {};
+  for (const key in obj) {
+    if (obj[key] != null) params[key] = obj[key];
+  }
+  return new URLSearchParams(params);
+}
+
+function parseJwt(token: string | undefined) {
+  const base64Url = (token ?? '').split('.')[1];
+
+  // exit early on invalid value
+  if (!base64Url) return {};
+
+  const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+  const jsonPayload = decodeURIComponent(
+    atob(base64)
+      .split('')
+      .map(function (c) {
+        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+      })
+      .join('')
+  );
+  return JSON.parse(jsonPayload);
 }

--- a/src/components/video-loader.ts
+++ b/src/components/video-loader.ts
@@ -1,0 +1,40 @@
+import { config } from './utils.js';
+import type { Asset } from '../assets.js';
+import type { VideoLoaderProps, VideoLoaderPropsWithConfig, VideoLoaderWithConfig } from './types';
+
+export async function defaultLoader({ config, src, width, height }: VideoLoaderPropsWithConfig) {
+  let requestUrl = `${config.path}?url=${encodeURIComponent(src)}`;
+  if (width) requestUrl += `&w=${width}`;
+  if (height) requestUrl += `&h=${height}`;
+  return `${requestUrl}`;
+}
+
+export function createVideoRequest(
+  loader: VideoLoaderWithConfig,
+  props: VideoLoaderProps,
+  callback: (json: Asset) => void
+) {
+  return async (abortSignal: AbortSignal) => {
+    if (typeof props.src === 'object') return;
+
+    try {
+      const requestUrl = await loader({
+        ...props,
+        config,
+      });
+      const res = await fetch(requestUrl, { signal: abortSignal });
+      const json = await res.json();
+      if (res.ok) {
+        callback(json);
+      } else {
+        let message = `[next-video] The request to ${res.url} failed. `;
+        message += `Did you configure the \`${config.path}\` route to handle video API requests?\n`;
+        throw new Error(message);
+      }
+    } catch (err) {
+      if (!abortSignal.aborted) {
+        console.error(err)
+      }
+    }
+  }
+}

--- a/src/components/video.tsx
+++ b/src/components/video.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { forwardRef, useState } from 'react';
-import DefaultPlayer from './default-player.js';
+import { DefaultPlayer } from './default-player.js';
 import { Alert } from './alert.js';
 import { createVideoRequest, defaultLoader } from './video-loader.js';
-import {  getPosterURLFromPlaybackId, toSymlinkPath, usePolling } from './utils.js';
+import { toSymlinkPath, usePolling } from './utils.js';
 
 import type { DefaultPlayerRefAttributes, DefaultPlayerProps } from './default-player.js';
 import type { Asset } from '../assets.js';
@@ -15,12 +15,10 @@ const DEV_MODE = process.env.NODE_ENV === 'development';
 const NextVideo = forwardRef<DefaultPlayerRefAttributes | null, VideoProps>((props: VideoProps, forwardedRef) => {
   let {
     as: VideoPlayer = DefaultPlayer,
-    children,
+    loader = defaultLoader,
     src,
     width,
     height,
-    controls = true,
-    loader = defaultLoader
   } = props;
 
   let [asset, setAsset] = useState(src);
@@ -38,21 +36,8 @@ const NextVideo = forwardRef<DefaultPlayerRefAttributes | null, VideoProps>((pro
   const needsPolling = DEV_MODE && (typeof asset === 'string' || status != 'ready');
   usePolling(request, needsPolling ? 1000 : null);
 
-  let { blurDataURL, poster, ...posterProps } = getPosterProps(props, { asset });
+  let posterProps = getPosterProps(props, { asset });
   let videoProps = getVideoProps(props, { asset });
-
-  // The default player supports a poster image slot which improves the loading speed.
-  if (VideoPlayer === DefaultPlayer && poster) {
-    poster = '';
-    children = <>
-      {children}
-      <img
-        slot="poster"
-        {...posterProps}
-        style={{ backgroundImage: blurDataURL ? `url('${blurDataURL}')` : undefined }}
-      />
-    </>
-  }
 
   return (
     <div className="next-video-container">
@@ -84,18 +69,13 @@ const NextVideo = forwardRef<DefaultPlayerRefAttributes | null, VideoProps>((pro
       <VideoPlayer
         ref={forwardedRef}
         data-next-video={status ?? ''}
-        poster={poster}
-        style={{
-          '--controls': controls === false ? 'none' : undefined,
-          width,
-          height,
-        }}
+        style={{ width, height }}
+        status={status}
         onPlaying={() => setPlaying(true)}
         onPause={() => setPlaying(false)}
+        {...posterProps}
         {...videoProps}
-      >
-        {children}
-      </VideoPlayer>
+      ></VideoPlayer>
 
       {DEV_MODE && <Alert
         hidden={Boolean(playing || !status || status === 'ready')}
@@ -109,26 +89,23 @@ export function getVideoProps(allProps: VideoProps, state: { asset: Asset | stri
   const { asset } = state;
   // Remove props that are not needed for VideoPlayer.
   const {
+    controls = true,
     as,
-    children,
     src,
-    width,
-    height,
     poster,
     blurDataURL,
-    sizes,
-    controls,
     loader,
     ...rest
   } = allProps;
-  const props: DefaultPlayerProps = { ...rest };
+
+  const props: DefaultPlayerProps = {
+    controls,
+    src: asset,
+    ...rest
+  };
 
   if (typeof asset === 'object') {
-    let playbackId = asset.externalIds?.playbackId;
-
-    if (asset.status === 'ready' && playbackId) {
-      props.playbackId = playbackId;
-    } else {
+    if (asset.status !== 'ready') {
       props.src = toSymlinkPath(asset.originalFilePath);
     }
   }
@@ -139,31 +116,15 @@ export function getVideoProps(allProps: VideoProps, state: { asset: Asset | stri
 export function getPosterProps(allProps: VideoProps, state: { asset: Asset | string }) {
   const { asset } = state;
   let { poster, blurDataURL } = allProps;
-  let srcSet;
 
   if (typeof asset === 'object') {
-    let playbackId = asset.externalIds?.playbackId;
-
-    if (asset.status === 'ready' && playbackId) {
-
-      if (!poster) {
-        poster = getPosterURLFromPlaybackId(playbackId, allProps);
-        srcSet =
-          `${getPosterURLFromPlaybackId(playbackId, { ...allProps, width: 480 })} 480w,` +
-          `${getPosterURLFromPlaybackId(playbackId, { ...allProps, width: 640 })} 640w,` +
-          `${getPosterURLFromPlaybackId(playbackId, { ...allProps, width: 960 })} 960w,` +
-          `${getPosterURLFromPlaybackId(playbackId, { ...allProps, width: 1280 })} 1280w,` +
-          `${getPosterURLFromPlaybackId(playbackId, { ...allProps, width: 1600 })} 1600w,` +
-          `${poster} 1920w`;
-      }
-
+    if (asset.status === 'ready') {
       blurDataURL = blurDataURL ?? asset.blurDataURL;
     }
   }
 
   return {
     poster,
-    srcSet,
     blurDataURL,
   };
 }

--- a/src/components/video.tsx
+++ b/src/components/video.tsx
@@ -1,139 +1,58 @@
 'use client';
 
-// todo: fix mux-player to work with moduleResolution: 'nodenext'?
 import { forwardRef, useState } from 'react';
-import MuxPlayer from '@mux/mux-player-react';
+import DefaultPlayer from './default-player.js';
 import { Alert } from './alert.js';
-import { getPosterURLFromPlaybackId, usePolling } from './utils.js';
+import { createVideoRequest, defaultLoader } from './video-loader.js';
+import {  getPosterURLFromPlaybackId, toSymlinkPath, usePolling } from './utils.js';
 
-import type { MuxPlayerRefAttributes, MuxPlayerProps } from '@mux/mux-player-react';
+import type { DefaultPlayerRefAttributes, DefaultPlayerProps } from './default-player.js';
 import type { Asset } from '../assets.js';
-import type { VideoConfig } from '../config.js';
-
-declare module 'react' {
-  interface CSSProperties {
-    [key: `--${string}`]: any;
-  }
-}
-
-export interface VideoProps extends Omit<MuxPlayerProps, 'src'> {
-  /**
-   * An imported video source object or a string video source URL.
-   * Can be a local or remote video file.
-   * If it's a string be sure to create an API endpoint to handle the request.
-   */
-  src: Asset | string;
-
-  /**
-   * Give a fixed width to the video.
-   */
-  width?: number;
-
-  /**
-   * Give a fixed height to the video.
-   */
-  height?: number;
-
-  /**
-   * Set to false to hide the video controls.
-   */
-  controls?: boolean;
-
-  /**
-   * Set a manual data URL to be used as a placeholder image before the poster image successfully loads.
-   * For imported videos this will be automatically generated.
-   */
-  blurDataURL?: string;
-
-  /**
-   * For best image loading performance the user should provide the sizes attribute.
-   * The width of the image in the webpage. e.g. sizes="800px". Defaults to 100vw.
-   * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#sizes
-   */
-  sizes?: string;
-
-  /**
-   * A custom function used to resolve video URLs.
-   */
-  loader?: VideoLoader;
-}
-
-export type VideoLoader = (p: VideoLoaderProps) => Promise<string>;
-
-export interface VideoLoaderProps {
-  src: string;
-  width?: number;
-  height?: number;
-}
-
-type VideoLoaderPropsWithConfig = VideoLoaderProps & {
-  config: Readonly<VideoConfig>
-}
+import type { VideoLoaderProps, VideoProps } from './types.js';
 
 const DEV_MODE = process.env.NODE_ENV === 'development';
 
-const config = JSON.parse(
-  process.env.NEXT_PUBLIC_DEV_VIDEO_OPTS
-  ?? process.env.NEXT_PUBLIC_VIDEO_OPTS
-  ?? '{}'
-);
-
-const FILES_FOLDER = `${config.folder ?? 'videos'}/`;
-
-const toSymlinkPath = (path?: string) => {
-  if (!path?.startsWith(FILES_FOLDER)) return path;
-  return path?.replace(FILES_FOLDER, `_${FILES_FOLDER}`);
-}
-
-const NextVideo = forwardRef<MuxPlayerRefAttributes | null, VideoProps>((props: VideoProps, forwardedRef) => {
+const NextVideo = forwardRef<DefaultPlayerRefAttributes | null, VideoProps>((props: VideoProps, forwardedRef) => {
   let {
+    as: VideoPlayer = DefaultPlayer,
+    children,
     src,
     width,
     height,
     controls = true,
     loader = defaultLoader
   } = props;
+
   let [asset, setAsset] = useState(src);
+  const [playing, setPlaying] = useState(false);
 
   // Required to make Next.js fast refresh when the local JSON file changes.
   // https://nextjs.org/docs/architecture/fast-refresh#fast-refresh-and-hooks
   if (typeof src === 'object') asset = src;
 
-  const status = typeof asset === 'object' ? asset.status : undefined;
+  // If the source is a string, poll the server for the JSON file.
+  const loaderProps: VideoLoaderProps = { src: asset as string, width, height };
+  const request = createVideoRequest(loader, loaderProps, (json) => setAsset(json));
 
-  let { blurDataURL, ...posterProps } = getPosterProps(props, { asset });
+  const status = typeof asset === 'object' ? asset.status : undefined;
+  const needsPolling = DEV_MODE && (typeof asset === 'string' || status != 'ready');
+  usePolling(request, needsPolling ? 1000 : null);
+
+  let { blurDataURL, poster, ...posterProps } = getPosterProps(props, { asset });
   let videoProps = getVideoProps(props, { asset });
 
-  async function fetchItems(abortSignal: AbortSignal) {
-    if (typeof asset === 'object') return;
-
-    try {
-      const requestUrl = await loader({
-        src: asset,
-        config,
-        width,
-        height
-      });
-      const res = await fetch(requestUrl, { signal: abortSignal });
-      const json = await res.json();
-      if (res.ok) {
-        setAsset(json);
-      } else {
-        let message = `[next-video] The request to ${res.url} failed. `;
-        message += `Did you configure the \`${config.path}\` route to handle video API requests?\n`;
-        throw new Error(message);
-      }
-    } catch (err) {
-      if (!abortSignal.aborted) {
-        console.error(err)
-      }
-    }
+  // The default player supports a poster image slot which improves the loading speed.
+  if (VideoPlayer === DefaultPlayer && poster) {
+    poster = '';
+    children = <>
+      {children}
+      <img
+        slot="poster"
+        {...posterProps}
+        style={{ backgroundImage: blurDataURL ? `url('${blurDataURL}')` : undefined }}
+      />
+    </>
   }
-
-  const needsPolling = DEV_MODE && (typeof asset === 'string' || status != 'ready');
-  usePolling(fetchItems, needsPolling ? 1000 : null);
-
-  const [playing, setPlaying] = useState(false);
 
   return (
     <div className="next-video-container">
@@ -161,10 +80,11 @@ const NextVideo = forwardRef<MuxPlayerRefAttributes | null, VideoProps>((props: 
         }
         `
       }</style>
-      <MuxPlayer
+
+      <VideoPlayer
         ref={forwardedRef}
         data-next-video={status ?? ''}
-        poster=""
+        poster={poster}
         style={{
           '--controls': controls === false ? 'none' : undefined,
           width,
@@ -174,12 +94,9 @@ const NextVideo = forwardRef<MuxPlayerRefAttributes | null, VideoProps>((props: 
         onPause={() => setPlaying(false)}
         {...videoProps}
       >
-        {posterProps.poster && <img
-          slot="poster"
-          {...posterProps}
-          style={{ backgroundImage: blurDataURL ? `url('${blurDataURL}')` : undefined }} />
-        }
-      </MuxPlayer>
+        {children}
+      </VideoPlayer>
+
       {DEV_MODE && <Alert
         hidden={Boolean(playing || !status || status === 'ready')}
         status={status}
@@ -188,17 +105,12 @@ const NextVideo = forwardRef<MuxPlayerRefAttributes | null, VideoProps>((props: 
   );
 });
 
-function defaultLoader({ config, src, width, height }: VideoLoaderPropsWithConfig) {
-  let requestUrl = `${config.path}?url=${encodeURIComponent(src)}`;
-  if (width) requestUrl += `&w=${width}`;
-  if (height) requestUrl += `&h=${height}`;
-  return `${requestUrl}`;
-}
-
-function getVideoProps(allProps: VideoProps, state: { asset: Asset | string }) {
+export function getVideoProps(allProps: VideoProps, state: { asset: Asset | string }) {
   const { asset } = state;
-  // Remove props that are not needed for MuxPlayer.
+  // Remove props that are not needed for VideoPlayer.
   const {
+    as,
+    children,
     src,
     width,
     height,
@@ -209,7 +121,7 @@ function getVideoProps(allProps: VideoProps, state: { asset: Asset | string }) {
     loader,
     ...rest
   } = allProps;
-  const props: MuxPlayerProps = { ...rest };
+  const props: DefaultPlayerProps = { ...rest };
 
   if (typeof asset === 'object') {
     let playbackId = asset.externalIds?.playbackId;
@@ -224,7 +136,7 @@ function getVideoProps(allProps: VideoProps, state: { asset: Asset | string }) {
   return props;
 }
 
-function getPosterProps(allProps: VideoProps, state: { asset: Asset | string }) {
+export function getPosterProps(allProps: VideoProps, state: { asset: Asset | string }) {
   const { asset } = state;
   let { poster, blurDataURL } = allProps;
   let srcSet;


### PR DESCRIPTION
fixes #77

This PR adds a new `as` property, lots of reshaping and extracted the provider (Mux) part from the default player (Mux) part. There is a prop called `asset` that is passed to the (custom) Player, this might need some discussion. 
