### PR TITLE
Hide poster from screen readers

### DIFF
--- a/src/components/default-player.tsx
+++ b/src/components/default-player.tsx
@@ -50,6 +50,7 @@ export const DefaultPlayer = forwardRef<DefaultPlayerRefAttributes | null, Defau
         slot="poster"
         srcSet={srcSet}
         style={{ backgroundImage: blurDataURL ? `url('${blurDataURL}')` : undefined }}
+        aria-hidden="true"
       />
     </>
   }


### PR DESCRIPTION
Noticed this issue in next-video-site's [page speed insights](https://pagespeed.web.dev/analysis/https-next-video-dev/kzzh1bjaiu?form_factor=mobile)

<img width="970" alt="the poster in next video doesn't have an alt description" src="https://github.com/muxinc/next-video/assets/8933386/45d63423-0978-4f56-b97e-c38d498847f1">


Following the example of the [underlying media-chrome-image component's default](https://github.com/muxinc/media-chrome/blob/db3f0f64e5fd6da12f996a9cbff1854bf45803ab/src/js/media-poster-image.js#L32), I propose we add `aria-hidden="true"` to next-video's poster.