### PR TITLE
fix: gitignore generation excluding json files

### DIFF
--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -16,11 +16,13 @@ const DEFAULT_DIR = 'videos';
 const DEV_SCRIPT = '& npx next-video sync -w';
 
 const gitIgnoreContents = (videosDir: string) => `
+# next-video
 ${videosDir}/*
-${videosDir}/!*.json
-${videosDir}/!*.js
-${videosDir}/!*.ts
-public/_next-video`;
+!${videosDir}/*.json
+!${videosDir}/*.js
+!${videosDir}/*.ts
+public/_next-video
+`;
 
 async function preInitCheck(dir: string) {
   try {


### PR DESCRIPTION
Fixes the gitignore exclusion rules as they weren't taking affect. Vercel deployment after a basic setup and video import was failing because the json files were being ignored. Also adds a title to the rules to match nextjs's other sections and a newline at the end.