### PR TITLE
fix: webpack loader ERR_STRING_TOO_LONG

### DIFF
--- a/src/webpack-loader.ts
+++ b/src/webpack-loader.ts
@@ -2,7 +2,10 @@ import path from 'node:path';
 import { readFile, writeFile } from 'node:fs/promises';
 import { env } from 'node:process';
 
-export default async function loader(this: any, source: any) {
+// https://webpack.js.org/api/loaders#raw-loader
+export const raw = true;
+
+export default async function loader(this: any, source: Buffer) {
   const assetPath = path.resolve(getAssetConfigPath(this.resourcePath));
 
   this.addDependency(assetPath);


### PR DESCRIPTION
fix #107

Error: Cannot create a string longer than 0x1fffffe8 characters