### PR TITLE
feat: update schema, add provider key + transform

### DIFF
--- a/src/assets.ts
+++ b/src/assets.ts
@@ -12,8 +12,6 @@ export interface Asset {
     [provider: string]: { [key: string]: any }
   };
   blurDataURL?: string;
-  poster?: string;
-  sources?: AssetSource[];
   size?: number;
   error?: any;
   createdAt: number;
@@ -25,9 +23,14 @@ export interface Asset {
   };
 }
 
+export interface TransformedAsset extends Asset {
+  poster?: string;
+  sources?: AssetSource[];
+}
+
 export interface AssetSource {
   src: string;
-  type: string;
+  type?: string;
 }
 
 export async function getAsset(filePath: string): Promise<Asset | undefined> {

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -1,38 +1,68 @@
-import { env } from 'node:process';
-import { readFile, writeFile } from 'node:fs/promises';
+import { relative } from 'node:path';
+import { cwd } from 'node:process';
+import { stat, readFile, writeFile } from 'node:fs/promises';
+import { getVideoConfig } from './config.js';
+import { deepMerge } from './utils.js';
 
 export interface Asset {
-  status?: 'sourced' | 'pending' | 'uploading' | 'processing' | 'ready' | 'error';
-  error?: any;
-  originalFilePath?: string;
+  status: 'sourced' | 'pending' | 'uploading' | 'processing' | 'ready' | 'error';
+  originalFilePath: string;
+  provider: string;
+  providerSpecific?: {
+    [provider: string]: { [key: string]: any }
+  };
+  blurDataURL?: string;
+  poster?: string;
+  sources?: AssetSource[];
   size?: number;
+  error?: any;
+  createdAt: number;
+  updatedAt: number;
+
+  // Here for backwards compatibility with older assets.
   externalIds?: {
     [key: string]: string; // { uploadId, playbackId, assetId }
   };
-  blurDataURL?: string;
-  createdAt?: number;
-  updatedAt?: number;
+}
+
+export interface AssetSource {
+  src: string;
+  type: string;
 }
 
 export async function getAsset(filePath: string): Promise<Asset | undefined> {
-  const assetPath = getAssetConfigPath(filePath);
+  const assetPath = await getAssetConfigPath(filePath);
   const file = await readFile(assetPath);
   const asset = JSON.parse(file.toString());
-
   return asset;
 }
 
-export async function createAsset(filePath: string, assetDetails?: Asset): Promise<Asset | undefined> {
-  const assetPath = getAssetConfigPath(filePath);
+export async function createAsset(filePath: string, assetDetails?: Partial<Asset>) {
+  const videoConfig = await getVideoConfig();
+  const assetPath = await getAssetConfigPath(filePath);
+
+  let originalFilePath = filePath;
+  if (!isRemote(filePath))  {
+    originalFilePath = relative(cwd(), filePath);
+  }
 
   const newAssetDetails: Asset = {
+    status: 'pending', // overwritable
     ...assetDetails,
-    status: 'pending',
-    originalFilePath: filePath,
-    externalIds: {},
+    originalFilePath,
+    provider: videoConfig.provider,
+    providerSpecific: {},
     createdAt: Date.now(),
     updatedAt: Date.now(),
   };
+
+  if (!isRemote(filePath)) {
+    try {
+      newAssetDetails.size = (await stat(filePath))?.size;
+    } catch {
+      // Ignore error.
+    }
+  }
 
   try {
     await writeFile(assetPath, JSON.stringify(newAssetDetails), { flag: 'wx' });
@@ -47,29 +77,26 @@ export async function createAsset(filePath: string, assetDetails?: Asset): Promi
   return newAssetDetails;
 }
 
-export async function updateAsset(filePath: string, assetDetails: Asset): Promise<Asset> {
-  const assetPath = getAssetConfigPath(filePath);
-
+export async function updateAsset(filePath: string, assetDetails: Partial<Asset>) {
+  const assetPath = await getAssetConfigPath(filePath);
   const currentAsset = await getAsset(filePath);
 
-  const newAssetDetails = {
-    ...currentAsset,
-    ...assetDetails,
-    externalIds: {
-      ...currentAsset?.externalIds,
-      ...assetDetails.externalIds,
-    },
+  if (!currentAsset) {
+    throw new Error(`Asset not found: ${filePath}`);
+  }
+
+  const newAssetDetails = deepMerge(currentAsset, assetDetails, {
     updatedAt: Date.now(),
-  };
+  }) as Asset;
 
   await writeFile(assetPath, JSON.stringify(newAssetDetails));
 
   return newAssetDetails;
 }
 
-function getAssetConfigPath(filePath: string) {
+export async function getAssetConfigPath(filePath: string) {
   if (isRemote(filePath)) {
-    const VIDEOS_DIR = JSON.parse(env['__NEXT_VIDEO_OPTS'] ?? '{}').folder;
+    const VIDEOS_DIR = (await getVideoConfig()).folder;
     if (!VIDEOS_DIR) throw new Error('Missing video `folder` config.');
 
     // Add the asset directory and make remote url a safe file path.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 import process from 'node:process';
-import path from 'node:path';
 import nextEnv from '@next/env';
 import log from './logger.js';
 import yargs from 'yargs/yargs';
@@ -11,8 +10,3 @@ import * as sync from './cli/sync.js';
 nextEnv.loadEnvConfig(process.cwd(), undefined, log);
 
 yargs(process.argv.slice(2)).command(init).command(sync).demandCommand().help().argv;
-
-// Import the app's next.config.js file so the env variables
-// __NEXT_VIDEO_OPTS set in with-next-video can be used.
-import(path.resolve('next.config.js'))
-  .catch(() => log.error('Failed to load next.config.js'));

--- a/src/cli/sync.ts
+++ b/src/cli/sync.ts
@@ -2,13 +2,14 @@ import chalk from 'chalk';
 import chokidar from 'chokidar';
 import { Argv, Arguments } from 'yargs';
 
-import { env, cwd } from 'node:process';
-import { stat, readdir } from 'node:fs/promises';
+import { cwd } from 'node:process';
+import { readdir } from 'node:fs/promises';
 import path from 'node:path';
 
 import log from '../logger.js';
 import { callHandler } from '../process.js';
 import { createAsset, getAsset } from '../assets.js';
+import { getVideoConfig } from '../config.js';
 import { getNextVideoVersion } from './lib/json-configs.js';
 
 export const command = 'sync';
@@ -38,21 +39,14 @@ function watcher(dir: string) {
     persistent: true,
   });
 
-  watcher.on('add', async (filePath, stats) => {
-    const relativePath = path.relative(cwd(), filePath);
-    const newAsset = await createAsset(relativePath, {
-      size: stats?.size,
-    });
+  watcher.on('add', async (filePath) => {
+    const newAsset = await createAsset(filePath);
 
     if (newAsset) {
       log.add(`New file found: ${filePath}`);
-      return callHandler('local.video.added', newAsset, getCallHandlerConfig());
+      return callHandler('local.video.added', newAsset, await getVideoConfig());
     }
   });
-}
-
-function getCallHandlerConfig() {
-  return JSON.parse(env['__NEXT_VIDEO_OPTS'] ?? '{}');
 }
 
 export async function handler(argv: Arguments) {
@@ -76,16 +70,11 @@ export async function handler(argv: Arguments) {
     const newFileProcessor = async (file: string) => {
       log.info(log.label('Processing file:'), file);
 
-      const absolutePath = path.join(directoryPath, file);
-      const relativePath = path.relative(cwd(), absolutePath);
-      const stats = await stat(absolutePath);
-
-      const newAsset = await createAsset(relativePath, {
-        size: stats.size,
-      });
+      const filePath = path.join(directoryPath, file);
+      const newAsset = await createAsset(filePath);
 
       if (newAsset) {
-        return callHandler('local.video.added', newAsset, getCallHandlerConfig());
+        return callHandler('local.video.added', newAsset, await getVideoConfig());
       }
     };
 
@@ -99,7 +88,7 @@ export async function handler(argv: Arguments) {
       // it back through the local video handler.
       const assetStatus = existingAsset?.status;
       if (assetStatus && ['sourced', 'pending', 'uploading', 'processing'].includes(assetStatus)) {
-        return callHandler('local.video.added', existingAsset, getCallHandlerConfig());
+        return callHandler('local.video.added', existingAsset, await getVideoConfig());
       }
     };
 

--- a/src/cli/sync.ts
+++ b/src/cli/sync.ts
@@ -44,7 +44,8 @@ function watcher(dir: string) {
 
     if (newAsset) {
       log.add(`New file found: ${filePath}`);
-      return callHandler('local.video.added', newAsset, await getVideoConfig());
+      const videoConfig = await getVideoConfig();
+      return callHandler('local.video.added', newAsset, videoConfig);
     }
   });
 }
@@ -74,7 +75,8 @@ export async function handler(argv: Arguments) {
       const newAsset = await createAsset(filePath);
 
       if (newAsset) {
-        return callHandler('local.video.added', newAsset, await getVideoConfig());
+        const videoConfig = await getVideoConfig();
+        return callHandler('local.video.added', newAsset, videoConfig);
       }
     };
 
@@ -88,7 +90,8 @@ export async function handler(argv: Arguments) {
       // it back through the local video handler.
       const assetStatus = existingAsset?.status;
       if (assetStatus && ['sourced', 'pending', 'uploading', 'processing'].includes(assetStatus)) {
-        return callHandler('local.video.added', existingAsset, await getVideoConfig());
+        const videoConfig = await getVideoConfig();
+        return callHandler('local.video.added', existingAsset, videoConfig);
       }
     };
 

--- a/src/components/default-player.tsx
+++ b/src/components/default-player.tsx
@@ -1,6 +1,6 @@
 import { forwardRef } from 'react';
 import MuxPlayer from '@mux/mux-player-react';
-import { getPosterURLFromPlaybackId } from './utils.js';
+import { getPlaybackId, getPosterURLFromPlaybackId } from '../providers/mux/transformer.js';
 
 import type { MuxPlayerProps, MuxPlayerRefAttributes } from '@mux/mux-player-react';
 import type { PlayerProps } from './types.js';
@@ -24,7 +24,7 @@ export const DefaultPlayer = forwardRef<DefaultPlayerRefAttributes | null, Defau
 
   const props: MuxPlayerProps = rest;
   const imgStyleProps: React.CSSProperties = {};
-  const playbackId = asset?.externalIds?.playbackId;
+  const playbackId = asset ? getPlaybackId(asset) : undefined;
 
   let isCustomPoster = true;
   let srcSet: string | undefined;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,6 @@
+import { env } from 'node:process';
+import path from 'node:path';
+
 /**
  * Video configurations
  */
@@ -19,4 +22,21 @@ export const videoConfigDefault: VideoConfigComplete = {
   folder: 'videos',
   path: '/api/video',
   provider: 'mux',
+}
+
+/**
+ * The video config is set in `next.config.js` and passed to the `withNextVideo` function.
+ * The video config is then stored as an environment variable __NEXT_VIDEO_OPTS.
+ */
+export async function getVideoConfig(): Promise<VideoConfigComplete> {
+  if (!env['__NEXT_VIDEO_OPTS']) {
+    // Import the app's next.config.js file so the env variable
+    // __NEXT_VIDEO_OPTS set in with-next-video.ts can be used.
+    try {
+      await import(path.resolve('next.config.js'))
+    } catch {
+      console.error('Failed to load next.config.js');
+    }
+  }
+  return JSON.parse(env['__NEXT_VIDEO_OPTS'] ?? '{}');
 }

--- a/src/providers/mux/provider.ts
+++ b/src/providers/mux/provider.ts
@@ -259,7 +259,8 @@ export async function createThumbHash(imgUrl: string) {
   const response = await uFetch(imgUrl);
   const buffer = await response.arrayBuffer();
 
-  const { data, info } = await sharp(buffer).raw().ensureAlpha().toBuffer({ resolveWithObject: true });
+  const { data, info } = await sharp(buffer)
+    .raw().ensureAlpha().toBuffer({ resolveWithObject: true });
 
   // thumbhash is ESM only so dynamically import it.
   const { rgbaToThumbHash, thumbHashToDataURL } = await import('thumbhash');

--- a/src/providers/mux/transformer.ts
+++ b/src/providers/mux/transformer.ts
@@ -1,4 +1,4 @@
-import type { Asset } from '../../assets.js';
+import type { Asset, TransformedAsset } from '../../assets.js';
 
 type Props = {
   customDomain?: string;
@@ -16,7 +16,7 @@ type PosterProps = {
 
 const MUX_VIDEO_DOMAIN = 'mux.com';
 
-export function transform(asset: Asset, props?: Props) {
+export function transform(asset: Asset, props?: Props): TransformedAsset {
   const playbackId = getPlaybackId(asset);
   if (!playbackId) return asset;
 
@@ -25,7 +25,6 @@ export function transform(asset: Asset, props?: Props) {
 
     sources: [
       { src: `https://stream.mux.com/${playbackId}.m3u8`, type: 'application/x-mpegURL' }
-      // todo: add progressive downloads?
     ],
 
     poster: getPosterURLFromPlaybackId(playbackId, {
@@ -33,7 +32,7 @@ export function transform(asset: Asset, props?: Props) {
       thumbnailTime: props?.thumbnailTime ?? props?.startTime,
       token: props?.tokens?.thumbnail,
     })
-  }
+  };
 }
 
 export function getPlaybackId(asset: Asset): string | undefined {

--- a/src/providers/mux/transformer.ts
+++ b/src/providers/mux/transformer.ts
@@ -1,0 +1,93 @@
+import type { Asset } from '../../assets.js';
+
+type Props = {
+  customDomain?: string;
+  thumbnailTime?: number;
+  startTime?: number;
+  tokens?: { thumbnail?: string }
+};
+
+type PosterProps = {
+  customDomain?: string;
+  thumbnailTime?: number;
+  token?: string;
+  width?: number;
+}
+
+const MUX_VIDEO_DOMAIN = 'mux.com';
+
+export function transform(asset: Asset, props?: Props) {
+  const playbackId = getPlaybackId(asset);
+  if (!playbackId) return asset;
+
+  return {
+    ...asset,
+
+    sources: [
+      { src: `https://stream.mux.com/${playbackId}.m3u8`, type: 'application/x-mpegURL' }
+      // todo: add progressive downloads?
+    ],
+
+    poster: getPosterURLFromPlaybackId(playbackId, {
+      customDomain: props?.customDomain,
+      thumbnailTime: props?.thumbnailTime ?? props?.startTime,
+      token: props?.tokens?.thumbnail,
+    })
+  }
+}
+
+export function getPlaybackId(asset: Asset): string | undefined {
+  // Fallback to asset.externalIds for backwards compatibility with older assets.
+  const providerDetails = asset.providerSpecific?.mux ?? asset.externalIds;
+  return providerDetails?.playbackId;
+}
+
+export const getPosterURLFromPlaybackId = (
+  playbackId?: string,
+  { token, thumbnailTime, width, customDomain = MUX_VIDEO_DOMAIN }: PosterProps = {}
+) => {
+  // NOTE: thumbnailTime is not supported when using a signedURL/token. Remove under these cases. (CJP)
+  const time = token == null ? thumbnailTime : undefined;
+  const { aud } = parseJwt(token);
+
+  if (token && aud !== 't') {
+    return;
+  }
+
+  return `https://image.${customDomain}/${playbackId}/thumbnail.webp${toQuery({
+    token,
+    time,
+    width,
+  })}`;
+};
+
+function toQuery(obj: Record<string, any>) {
+  const params = toParams(obj).toString();
+  return params ? '?' + params : '';
+}
+
+function toParams(obj: Record<string, any>) {
+  const params: Record<string, any> = {};
+  for (const key in obj) {
+    if (obj[key] != null) params[key] = obj[key];
+  }
+  return new URLSearchParams(params);
+}
+
+function parseJwt(token: string | undefined) {
+  const base64Url = (token ?? '').split('.')[1];
+
+  // exit early on invalid value
+  if (!base64Url) return {};
+
+  const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+  const jsonPayload = decodeURIComponent(
+    atob(base64)
+      .split('')
+      .map(function (c) {
+        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+      })
+      .join('')
+  );
+  return JSON.parse(jsonPayload);
+}

--- a/src/providers/providers.ts
+++ b/src/providers/providers.ts
@@ -1,2 +1,2 @@
-export * as mux from './mux.js';
-export * as vercelBlob from './vercel-blob.js';
+export * as mux from './mux/provider.js';
+export * as vercelBlob from './vercel-blob/provider.js';

--- a/src/providers/transformers.ts
+++ b/src/providers/transformers.ts
@@ -1,0 +1,2 @@
+export * as mux from './mux/transformer.js';
+export * as vercelBlob from './vercel-blob/transformer.js';

--- a/src/providers/vercel-blob/provider.ts
+++ b/src/providers/vercel-blob/provider.ts
@@ -11,6 +11,11 @@ export const config = {
   runtime: 'edge',
 };
 
+export type VercelBlobSpecifics = {
+  url?: string;
+  contentType?: string;
+}
+
 export async function uploadLocalFile(asset: Asset) {
   if (!asset.originalFilePath) {
     log.error('No filePath provided for asset.');
@@ -62,10 +67,10 @@ export async function uploadLocalFile(asset: Asset) {
   return updateAsset(src, {
     status: 'ready',
     providerSpecific: {
-      [provider]: {
+      'vercel-blob': {
         url: blob.url,
         contentType: blob.contentType,
-      }
+      } as VercelBlobSpecifics
     },
   });
 }
@@ -108,10 +113,10 @@ export async function uploadRequestedFile(asset: Asset) {
   return updateAsset(src, {
     status: 'ready',
     providerSpecific: {
-      [provider]: {
+      'vercel-blob': {
         url: blob.url,
         contentType: blob.contentType,
-      }
+      } as VercelBlobSpecifics
     },
   });
 }

--- a/src/providers/vercel-blob/provider.ts
+++ b/src/providers/vercel-blob/provider.ts
@@ -63,12 +63,7 @@ export async function uploadLocalFile(asset: Asset) {
 
   return updateAsset(src, {
     status: 'ready',
-    providerSpecific: {
-      [provider]: {
-        url: blob.url,
-        contentType: blob.contentType,
-      }
-    },
+    sources: [{ src: blob.url, type: blob.contentType }],
   });
 }
 
@@ -109,11 +104,6 @@ export async function uploadRequestedFile(asset: Asset) {
 
   return updateAsset(src, {
     status: 'ready',
-    providerSpecific: {
-      [provider]: {
-        url: blob.url,
-        contentType: blob.contentType,
-      }
-    },
+    sources: [{ src: blob.url, type: blob.contentType }],
   });
 }

--- a/src/providers/vercel-blob/provider.ts
+++ b/src/providers/vercel-blob/provider.ts
@@ -61,7 +61,12 @@ export async function uploadLocalFile(asset: Asset) {
 
   return updateAsset(src, {
     status: 'ready',
-    sources: [{ src: blob.url, type: blob.contentType }],
+    providerSpecific: {
+      [provider]: {
+        url: blob.url,
+        contentType: blob.contentType,
+      }
+    },
   });
 }
 
@@ -102,6 +107,11 @@ export async function uploadRequestedFile(asset: Asset) {
 
   return updateAsset(src, {
     status: 'ready',
-    sources: [{ src: blob.url, type: blob.contentType }],
+    providerSpecific: {
+      [provider]: {
+        url: blob.url,
+        contentType: blob.contentType,
+      }
+    },
   });
 }

--- a/src/providers/vercel-blob/provider.ts
+++ b/src/providers/vercel-blob/provider.ts
@@ -7,8 +7,6 @@ import chalk from 'chalk';
 import { updateAsset, Asset } from '../../assets.js';
 import log from '../../logger.js';
 
-const provider = 'vercel-blob';
-
 export const config = {
   runtime: 'edge',
 };

--- a/src/providers/vercel-blob/provider.ts
+++ b/src/providers/vercel-blob/provider.ts
@@ -1,12 +1,13 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fetch as uFetch } from 'undici';
-import { put, head } from '@vercel/blob';
+import { put } from '@vercel/blob';
 import chalk from 'chalk';
 
-import { updateAsset, Asset } from '../assets.js';
-import log from '../logger.js';
+import { updateAsset, Asset } from '../../assets.js';
+import log from '../../logger.js';
 
+const provider = 'vercel-blob';
 
 export const config = {
   runtime: 'edge',
@@ -62,8 +63,11 @@ export async function uploadLocalFile(asset: Asset) {
 
   return updateAsset(src, {
     status: 'ready',
-    externalIds: {
-      url: blob.url,
+    providerSpecific: {
+      [provider]: {
+        url: blob.url,
+        contentType: blob.contentType,
+      }
     },
   });
 }
@@ -105,8 +109,11 @@ export async function uploadRequestedFile(asset: Asset) {
 
   return updateAsset(src, {
     status: 'ready',
-    externalIds: {
-      url: blob.url,
+    providerSpecific: {
+      [provider]: {
+        url: blob.url,
+        contentType: blob.contentType,
+      }
     },
   });
 }

--- a/src/providers/vercel-blob/transformer.ts
+++ b/src/providers/vercel-blob/transformer.ts
@@ -1,11 +1,11 @@
-import type { Asset } from '../../assets.js';
+import type { Asset, TransformedAsset, AssetSource } from '../../assets.js';
 
-export function transform(asset: Asset) {
+export function transform(asset: Asset): TransformedAsset {
   // Fallback to asset.externalIds for backwards compatibility with older assets.
   const providerDetails = asset.providerSpecific?.['vercel-blob'] ?? asset.externalIds;
   if (!providerDetails) return asset;
 
-  const source: Record<string, string> = {
+  const source: AssetSource = {
     src: providerDetails.url
   };
 

--- a/src/providers/vercel-blob/transformer.ts
+++ b/src/providers/vercel-blob/transformer.ts
@@ -2,16 +2,12 @@ import type { Asset } from '../../assets.js';
 
 export function transform(asset: Asset) {
   // Fallback to asset.externalIds for backwards compatibility with older assets.
-  const providerDetails = asset.providerSpecific?.['vercel-blob'] ?? asset.externalIds;
+  const providerDetails = asset.externalIds;
   if (!providerDetails) return asset;
 
   const source: Record<string, string> = {
     src: providerDetails.url
   };
-
-  if (providerDetails.contentType) {
-    source.type = providerDetails.contentType;
-  }
 
   return {
     ...asset,

--- a/src/providers/vercel-blob/transformer.ts
+++ b/src/providers/vercel-blob/transformer.ts
@@ -1,0 +1,20 @@
+import type { Asset } from '../../assets.js';
+
+export function transform(asset: Asset) {
+  // Fallback to asset.externalIds for backwards compatibility with older assets.
+  const providerDetails = asset.providerSpecific?.['vercel-blob'] ?? asset.externalIds;
+  if (!providerDetails) return asset;
+
+  const source: Record<string, string> = {
+    src: providerDetails.url
+  };
+
+  if (providerDetails.contentType) {
+    source.type = providerDetails.contentType;
+  }
+
+  return {
+    ...asset,
+    sources: [source],
+  };
+}

--- a/src/providers/vercel-blob/transformer.ts
+++ b/src/providers/vercel-blob/transformer.ts
@@ -2,12 +2,16 @@ import type { Asset } from '../../assets.js';
 
 export function transform(asset: Asset) {
   // Fallback to asset.externalIds for backwards compatibility with older assets.
-  const providerDetails = asset.externalIds;
+  const providerDetails = asset.providerSpecific?.['vercel-blob'] ?? asset.externalIds;
   if (!providerDetails) return asset;
 
   const source: Record<string, string> = {
     src: providerDetails.url
   };
+
+  if (providerDetails.contentType) {
+    source.type = providerDetails.contentType;
+  }
 
   return {
     ...asset,

--- a/src/request-handler.ts
+++ b/src/request-handler.ts
@@ -45,7 +45,8 @@ async function handleRequest(url?: string | null) {
     asset = await createAsset(url);
 
     if (asset) {
-      await callHandler('request.video.added', asset, await getVideoConfig());
+      const videoConfig = await getVideoConfig();
+      await callHandler('request.video.added', asset, videoConfig);
     }
 
     return { status: 200, data: asset };

--- a/src/request-handler.ts
+++ b/src/request-handler.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { env } from 'node:process';
 import { callHandler } from './process.js';
 import { createAsset, getAsset } from './assets.js';
+import { getVideoConfig } from './config.js';
 
 // App Router
 export async function GET(request: Request) {
@@ -45,15 +45,11 @@ async function handleRequest(url?: string | null) {
     asset = await createAsset(url);
 
     if (asset) {
-      await callHandler('request.video.added', asset, getCallHandlerConfig());
+      await callHandler('request.video.added', asset, await getVideoConfig());
     }
 
     return { status: 200, data: asset };
   }
 
   return { status: 200, data: asset };
-}
-
-function getCallHandlerConfig() {
-  return JSON.parse(env['__NEXT_VIDEO_OPTS'] ?? '{}');
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,7 @@
+export function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 export function camelCase(name: string) {
   return name.replace(/[-_]([a-z])/g, ($0, $1) => $1.toUpperCase());
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,29 @@
-
 export function camelCase(name: string) {
   return name.replace(/[-_]([a-z])/g, ($0, $1) => $1.toUpperCase());
+}
+
+/**
+* Performs a deep merge of objects and returns a new object.
+* Does not modify objects (immutable) and merges arrays via concatenation.
+*/
+export function deepMerge(...objects: any[]) {
+  const result: any = {};
+  for (const obj of objects) {
+    for (const key in obj) {
+      const existing = result[key];
+      const val = obj[key];
+      if (Array.isArray(val) && Array.isArray(existing)) {
+        result[key] = existing.concat(...val);
+      } else if (isObject(val) && isObject(existing)) {
+        result[key] = deepMerge(existing, val);
+      } else {
+        result[key] = val;
+      }
+    }
+  }
+  return result;
+}
+
+export function isObject(item: any) {
+  return (item && typeof item === 'object' && !Array.isArray(item));
 }

--- a/src/webpack-loader.ts
+++ b/src/webpack-loader.ts
@@ -1,53 +1,23 @@
 import path from 'node:path';
-import { readFile, writeFile } from 'node:fs/promises';
-import { env } from 'node:process';
+import { readFile } from 'node:fs/promises';
+import { createAsset, getAssetConfigPath } from './assets.js';
 
 // https://webpack.js.org/api/loaders#raw-loader
 export const raw = true;
 
 export default async function loader(this: any, source: Buffer) {
-  const assetPath = path.resolve(getAssetConfigPath(this.resourcePath));
+  const assetPath = path.resolve(await getAssetConfigPath(this.resourcePath));
 
   this.addDependency(assetPath);
 
   let asset;
-
   try {
     asset = await readFile(assetPath, 'utf-8');
   } catch {
-
-    const originalFilePath = isRemote(this.resourcePath)
-      ? this.resourcePath
-      : path.relative(process.cwd(), this.resourcePath);
-
-    asset = JSON.stringify({
-      status: 'sourced',
-      originalFilePath
-    });
-
-    await writeFile(assetPath, asset, { flag: 'wx' });
+    asset = JSON.stringify(await createAsset(this.resourcePath, {
+      status: 'sourced'
+    }));
   }
 
   return `export default ${asset}`;
-}
-
-function getAssetConfigPath(filePath: string) {
-  if (isRemote(filePath)) {
-    const VIDEOS_DIR = JSON.parse(env['__NEXT_VIDEO_OPTS'] ?? '{}').folder;
-    if (!VIDEOS_DIR) throw new Error('Missing video `folder` config.');
-
-    // Add the asset directory and make remote url a safe file path.
-    return `${VIDEOS_DIR}/${toSafePath(filePath)}.json`;
-  }
-  return `${filePath}.json`
-}
-
-function isRemote(filePath: string) {
-  return /^https?:\/\//.test(filePath);
-}
-
-function toSafePath(str: string) {
-  return str
-    .replace(/^[^a-zA-Z0-9]+|[^a-zA-Z0-9]+$/g, '')
-    .replace(/[^a-zA-Z0-9._-]+/g, '_');
 }

--- a/src/with-next-video.ts
+++ b/src/with-next-video.ts
@@ -16,17 +16,17 @@ export async function withNextVideo(nextConfig: any, videoConfig?: VideoConfig) 
   }
 
   const videoConfigComplete = Object.assign({}, videoConfigDefault, videoConfig);
-  const { path, folder } = videoConfigComplete;
+  const { path, folder, provider } = videoConfigComplete;
 
   // Don't use `process.env` here because Next.js replaces public env vars during build.
-  env['NEXT_PUBLIC_VIDEO_OPTS'] = JSON.stringify({ path });
+  env['NEXT_PUBLIC_VIDEO_OPTS'] = JSON.stringify({ path, provider });
   env['__NEXT_VIDEO_OPTS'] = JSON.stringify(videoConfigComplete);
 
   // We should probably switch to using `phase` here, just a bit concerned about backwards compatibility.
   if (process.argv[2] === 'dev') {
 
     // Don't use `process.env` here because Next.js replaces public env vars during build.
-    env['NEXT_PUBLIC_DEV_VIDEO_OPTS'] = JSON.stringify({ path, folder });
+    env['NEXT_PUBLIC_DEV_VIDEO_OPTS'] = JSON.stringify({ path, folder, provider });
 
     const VIDEOS_PATH = join(process.cwd(), folder)
     const TMP_PUBLIC_VIDEOS_PATH = join(process.cwd(), 'public', `_next-video`);

--- a/tests/cli/sync.test.ts
+++ b/tests/cli/sync.test.ts
@@ -169,7 +169,9 @@ describe('cli', () => {
         await createAsset(filePath, {});
         await updateAsset(filePath, {
           status: 'pending',
-          externalIds: { assetId: 'fake-asset-id' },
+          providerSpecific: {
+            mux: { assetId: 'fake-asset-id' },
+          },
         });
 
         const { addSpy, successSpy } = logSpies(t);
@@ -190,7 +192,9 @@ describe('cli', () => {
         await createAsset(filePath, {});
         await updateAsset(filePath, {
           status: 'uploading',
-          externalIds: { assetId: 'fake-asset-id' },
+          providerSpecific: {
+            mux: { assetId: 'fake-asset-id' },
+          }
         });
 
         const { addSpy, successSpy } = logSpies(t);
@@ -211,7 +215,9 @@ describe('cli', () => {
         await createAsset(filePath, {});
         await updateAsset(filePath, {
           status: 'processing',
-          externalIds: { assetId: 'fake-asset-id' },
+          providerSpecific: {
+            mux: { assetId: 'fake-asset-id' },
+          }
         });
 
         const { addSpy, successSpy } = logSpies(t);

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import { deepMerge } from '../src/utils.js';
+
+describe('utils', () => {
+  it('deepMerge', () => {
+    const a = {
+      foo: {
+        bar: 'baz',
+        qux: 'quux',
+      },
+      beep: 'boop',
+      providerSpecific: {
+        mux: {
+          uploadId: '1',
+          assetId: '2',
+        }
+      }
+    };
+
+    const b = {
+      foo: {
+        bar: 'baz2',
+      },
+      beep: 'boop2',
+      providerSpecific: {
+        mux: {
+          assetId: '3',
+          playbackId: '4',
+        }
+      }
+    };
+
+    const c = deepMerge(a, b);
+
+    assert(c.foo.bar === 'baz2');
+    assert(c.foo.qux === 'quux');
+    assert(c.beep === 'boop2');
+    assert(c.providerSpecific.mux.uploadId === '1');
+    assert(c.providerSpecific.mux.assetId === '3');
+    assert(c.providerSpecific.mux.playbackId === '4');
+  });
+});


### PR DESCRIPTION
- this pr updates the asset schema to the schema below.
- `poster` and `sources` are derived data so I didn't add them to the stored state yet.
  to generate this derived data, `transformer`'s were added alongside the provider files.
  not in the same file as the provider, because the front-end needs to pull this in.
- I tried to add some more logic to assets.ts and re-use it where was possible.

```ts
export interface Asset {
  status: 'sourced' | 'pending' | 'uploading' | 'processing' | 'ready' | 'error';
  originalFilePath: string;
  provider: string;
  providerSpecific?: {
    [provider: string]: { [key: string]: any }
  };
  blurDataURL?: string;
  poster?: string;
  sources?: AssetSource[];
  size?: number;
  error?: any;
  createdAt: number;
  updatedAt: number;

  // Here for backwards compatibility with older assets.
  externalIds?: {
    [key: string]: string; // { uploadId, playbackId, assetId }
  };
}
```