### PR TITLE
fix: bundling related issues 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
-        "@aws-sdk/client-s3": "^3.461.0",
+        "@aws-sdk/client-s3": "~3.437.0",
         "@inquirer/prompts": "^3.2.0",
         "@mux/mux-node": "8.0.0-canary.0",
         "@mux/mux-player-react": "2.2.0",
@@ -180,66 +180,77 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.461.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.461.0.tgz",
-      "integrity": "sha512-pvEWMb2djn3bjD9lelYQhyG8KKKrUMm5MlSaSPwqVTL97iKm/Zbk+Ord6n8qMyPl5JHGmNdfg0tZFxC1qXeHTw==",
+      "version": "3.437.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.437.0.tgz",
+      "integrity": "sha512-KCocXvRH3pCTJNeNivDJN9mygK0B4Uvp5POWlCXgOj5iQU2U/sEpr+LqAwQZiZZjE7crcsAf0FPKMyk6/oMXHQ==",
       "dependencies": {
         "@aws-crypto/sha1-browser": "3.0.0",
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.461.0",
-        "@aws-sdk/core": "3.451.0",
-        "@aws-sdk/credential-provider-node": "3.460.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.460.0",
-        "@aws-sdk/middleware-expect-continue": "3.460.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.461.0",
-        "@aws-sdk/middleware-host-header": "3.460.0",
-        "@aws-sdk/middleware-location-constraint": "3.461.0",
-        "@aws-sdk/middleware-logger": "3.460.0",
-        "@aws-sdk/middleware-recursion-detection": "3.460.0",
-        "@aws-sdk/middleware-sdk-s3": "3.461.0",
-        "@aws-sdk/middleware-signing": "3.461.0",
-        "@aws-sdk/middleware-ssec": "3.460.0",
-        "@aws-sdk/middleware-user-agent": "3.460.0",
-        "@aws-sdk/region-config-resolver": "3.451.0",
-        "@aws-sdk/signature-v4-multi-region": "3.461.0",
-        "@aws-sdk/types": "3.460.0",
-        "@aws-sdk/util-endpoints": "3.460.0",
-        "@aws-sdk/util-user-agent-browser": "3.460.0",
-        "@aws-sdk/util-user-agent-node": "3.460.0",
+        "@aws-sdk/client-sts": "3.437.0",
+        "@aws-sdk/core": "3.436.0",
+        "@aws-sdk/credential-provider-node": "3.437.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.433.0",
+        "@aws-sdk/middleware-expect-continue": "3.433.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.433.0",
+        "@aws-sdk/middleware-host-header": "3.433.0",
+        "@aws-sdk/middleware-location-constraint": "3.433.0",
+        "@aws-sdk/middleware-logger": "3.433.0",
+        "@aws-sdk/middleware-recursion-detection": "3.433.0",
+        "@aws-sdk/middleware-sdk-s3": "3.433.0",
+        "@aws-sdk/middleware-signing": "3.433.0",
+        "@aws-sdk/middleware-ssec": "3.433.0",
+        "@aws-sdk/middleware-user-agent": "3.433.0",
+        "@aws-sdk/region-config-resolver": "3.433.0",
+        "@aws-sdk/signature-v4-multi-region": "3.437.0",
+        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/util-endpoints": "3.433.0",
+        "@aws-sdk/util-user-agent-browser": "3.433.0",
+        "@aws-sdk/util-user-agent-node": "3.437.0",
         "@aws-sdk/xml-builder": "3.310.0",
-        "@smithy/config-resolver": "^2.0.18",
-        "@smithy/eventstream-serde-browser": "^2.0.13",
-        "@smithy/eventstream-serde-config-resolver": "^2.0.13",
-        "@smithy/eventstream-serde-node": "^2.0.13",
-        "@smithy/fetch-http-handler": "^2.2.6",
-        "@smithy/hash-blob-browser": "^2.0.14",
-        "@smithy/hash-node": "^2.0.15",
-        "@smithy/hash-stream-node": "^2.0.15",
-        "@smithy/invalid-dependency": "^2.0.13",
-        "@smithy/md5-js": "^2.0.15",
-        "@smithy/middleware-content-length": "^2.0.15",
-        "@smithy/middleware-endpoint": "^2.2.0",
-        "@smithy/middleware-retry": "^2.0.20",
-        "@smithy/middleware-serde": "^2.0.13",
-        "@smithy/middleware-stack": "^2.0.7",
-        "@smithy/node-config-provider": "^2.1.5",
-        "@smithy/node-http-handler": "^2.1.9",
-        "@smithy/protocol-http": "^3.0.9",
-        "@smithy/smithy-client": "^2.1.15",
-        "@smithy/types": "^2.5.0",
-        "@smithy/url-parser": "^2.0.13",
-        "@smithy/util-base64": "^2.0.1",
+        "@smithy/config-resolver": "^2.0.16",
+        "@smithy/eventstream-serde-browser": "^2.0.12",
+        "@smithy/eventstream-serde-config-resolver": "^2.0.12",
+        "@smithy/eventstream-serde-node": "^2.0.12",
+        "@smithy/fetch-http-handler": "^2.2.4",
+        "@smithy/hash-blob-browser": "^2.0.12",
+        "@smithy/hash-node": "^2.0.12",
+        "@smithy/hash-stream-node": "^2.0.12",
+        "@smithy/invalid-dependency": "^2.0.12",
+        "@smithy/md5-js": "^2.0.12",
+        "@smithy/middleware-content-length": "^2.0.14",
+        "@smithy/middleware-endpoint": "^2.1.3",
+        "@smithy/middleware-retry": "^2.0.18",
+        "@smithy/middleware-serde": "^2.0.12",
+        "@smithy/middleware-stack": "^2.0.6",
+        "@smithy/node-config-provider": "^2.1.3",
+        "@smithy/node-http-handler": "^2.1.8",
+        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/smithy-client": "^2.1.12",
+        "@smithy/types": "^2.4.0",
+        "@smithy/url-parser": "^2.0.12",
+        "@smithy/util-base64": "^2.0.0",
         "@smithy/util-body-length-browser": "^2.0.0",
         "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.19",
-        "@smithy/util-defaults-mode-node": "^2.0.25",
-        "@smithy/util-endpoints": "^1.0.4",
-        "@smithy/util-retry": "^2.0.6",
-        "@smithy/util-stream": "^2.0.20",
-        "@smithy/util-utf8": "^2.0.2",
-        "@smithy/util-waiter": "^2.0.13",
+        "@smithy/util-defaults-mode-browser": "^2.0.16",
+        "@smithy/util-defaults-mode-node": "^2.0.21",
+        "@smithy/util-retry": "^2.0.5",
+        "@smithy/util-stream": "^2.0.17",
+        "@smithy/util-utf8": "^2.0.0",
+        "@smithy/util-waiter": "^2.0.12",
         "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/types": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
+      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -247,45 +258,56 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.460.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.460.0.tgz",
-      "integrity": "sha512-p5D9C8LKJs5yoBn5cCs2Wqzrp5YP5BYcP774bhGMFEu/LCIUyWzudwN3+/AObSiq8R8SSvBY2zQD4h+k3NjgTQ==",
+      "version": "3.437.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.437.0.tgz",
+      "integrity": "sha512-AxlLWz9ec3b8Bt+RqRb2Q1ucGQtKrLdKDna+UTjz7AouB/jpoMiegV9NHXVX64N6YFnQnvB0UEGigXiOQE+y/g==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/core": "3.451.0",
-        "@aws-sdk/middleware-host-header": "3.460.0",
-        "@aws-sdk/middleware-logger": "3.460.0",
-        "@aws-sdk/middleware-recursion-detection": "3.460.0",
-        "@aws-sdk/middleware-user-agent": "3.460.0",
-        "@aws-sdk/region-config-resolver": "3.451.0",
-        "@aws-sdk/types": "3.460.0",
-        "@aws-sdk/util-endpoints": "3.460.0",
-        "@aws-sdk/util-user-agent-browser": "3.460.0",
-        "@aws-sdk/util-user-agent-node": "3.460.0",
-        "@smithy/config-resolver": "^2.0.18",
-        "@smithy/fetch-http-handler": "^2.2.6",
-        "@smithy/hash-node": "^2.0.15",
-        "@smithy/invalid-dependency": "^2.0.13",
-        "@smithy/middleware-content-length": "^2.0.15",
-        "@smithy/middleware-endpoint": "^2.2.0",
-        "@smithy/middleware-retry": "^2.0.20",
-        "@smithy/middleware-serde": "^2.0.13",
-        "@smithy/middleware-stack": "^2.0.7",
-        "@smithy/node-config-provider": "^2.1.5",
-        "@smithy/node-http-handler": "^2.1.9",
-        "@smithy/protocol-http": "^3.0.9",
-        "@smithy/smithy-client": "^2.1.15",
-        "@smithy/types": "^2.5.0",
-        "@smithy/url-parser": "^2.0.13",
-        "@smithy/util-base64": "^2.0.1",
+        "@aws-sdk/core": "3.436.0",
+        "@aws-sdk/middleware-host-header": "3.433.0",
+        "@aws-sdk/middleware-logger": "3.433.0",
+        "@aws-sdk/middleware-recursion-detection": "3.433.0",
+        "@aws-sdk/middleware-user-agent": "3.433.0",
+        "@aws-sdk/region-config-resolver": "3.433.0",
+        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/util-endpoints": "3.433.0",
+        "@aws-sdk/util-user-agent-browser": "3.433.0",
+        "@aws-sdk/util-user-agent-node": "3.437.0",
+        "@smithy/config-resolver": "^2.0.16",
+        "@smithy/fetch-http-handler": "^2.2.4",
+        "@smithy/hash-node": "^2.0.12",
+        "@smithy/invalid-dependency": "^2.0.12",
+        "@smithy/middleware-content-length": "^2.0.14",
+        "@smithy/middleware-endpoint": "^2.1.3",
+        "@smithy/middleware-retry": "^2.0.18",
+        "@smithy/middleware-serde": "^2.0.12",
+        "@smithy/middleware-stack": "^2.0.6",
+        "@smithy/node-config-provider": "^2.1.3",
+        "@smithy/node-http-handler": "^2.1.8",
+        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/smithy-client": "^2.1.12",
+        "@smithy/types": "^2.4.0",
+        "@smithy/url-parser": "^2.0.12",
+        "@smithy/util-base64": "^2.0.0",
         "@smithy/util-body-length-browser": "^2.0.0",
         "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.19",
-        "@smithy/util-defaults-mode-node": "^2.0.25",
-        "@smithy/util-endpoints": "^1.0.4",
-        "@smithy/util-retry": "^2.0.6",
-        "@smithy/util-utf8": "^2.0.2",
+        "@smithy/util-defaults-mode-browser": "^2.0.16",
+        "@smithy/util-defaults-mode-node": "^2.0.21",
+        "@smithy/util-retry": "^2.0.5",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/types": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
+      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -293,48 +315,47 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.461.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.461.0.tgz",
-      "integrity": "sha512-1u+t31m23vuc9zkiUk51L4QbwuRQEuBeMArHK/thmq4V+A0VmjoAr/x2D0eQ0deOuBqG5YC62oaqUfIhj03SIw==",
+      "version": "3.437.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.437.0.tgz",
+      "integrity": "sha512-ilLcrCVwH81UbKNpB9Vax1Fw/mNx2d/bWXkCNXPvrExO+K39VFGS/VijOuSrru2iBq844NlG3uQV8DL/nbiKdA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/core": "3.451.0",
-        "@aws-sdk/credential-provider-node": "3.460.0",
-        "@aws-sdk/middleware-host-header": "3.460.0",
-        "@aws-sdk/middleware-logger": "3.460.0",
-        "@aws-sdk/middleware-recursion-detection": "3.460.0",
-        "@aws-sdk/middleware-sdk-sts": "3.461.0",
-        "@aws-sdk/middleware-signing": "3.461.0",
-        "@aws-sdk/middleware-user-agent": "3.460.0",
-        "@aws-sdk/region-config-resolver": "3.451.0",
-        "@aws-sdk/types": "3.460.0",
-        "@aws-sdk/util-endpoints": "3.460.0",
-        "@aws-sdk/util-user-agent-browser": "3.460.0",
-        "@aws-sdk/util-user-agent-node": "3.460.0",
-        "@smithy/config-resolver": "^2.0.18",
-        "@smithy/fetch-http-handler": "^2.2.6",
-        "@smithy/hash-node": "^2.0.15",
-        "@smithy/invalid-dependency": "^2.0.13",
-        "@smithy/middleware-content-length": "^2.0.15",
-        "@smithy/middleware-endpoint": "^2.2.0",
-        "@smithy/middleware-retry": "^2.0.20",
-        "@smithy/middleware-serde": "^2.0.13",
-        "@smithy/middleware-stack": "^2.0.7",
-        "@smithy/node-config-provider": "^2.1.5",
-        "@smithy/node-http-handler": "^2.1.9",
-        "@smithy/protocol-http": "^3.0.9",
-        "@smithy/smithy-client": "^2.1.15",
-        "@smithy/types": "^2.5.0",
-        "@smithy/url-parser": "^2.0.13",
-        "@smithy/util-base64": "^2.0.1",
+        "@aws-sdk/core": "3.436.0",
+        "@aws-sdk/credential-provider-node": "3.437.0",
+        "@aws-sdk/middleware-host-header": "3.433.0",
+        "@aws-sdk/middleware-logger": "3.433.0",
+        "@aws-sdk/middleware-recursion-detection": "3.433.0",
+        "@aws-sdk/middleware-sdk-sts": "3.433.0",
+        "@aws-sdk/middleware-signing": "3.433.0",
+        "@aws-sdk/middleware-user-agent": "3.433.0",
+        "@aws-sdk/region-config-resolver": "3.433.0",
+        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/util-endpoints": "3.433.0",
+        "@aws-sdk/util-user-agent-browser": "3.433.0",
+        "@aws-sdk/util-user-agent-node": "3.437.0",
+        "@smithy/config-resolver": "^2.0.16",
+        "@smithy/fetch-http-handler": "^2.2.4",
+        "@smithy/hash-node": "^2.0.12",
+        "@smithy/invalid-dependency": "^2.0.12",
+        "@smithy/middleware-content-length": "^2.0.14",
+        "@smithy/middleware-endpoint": "^2.1.3",
+        "@smithy/middleware-retry": "^2.0.18",
+        "@smithy/middleware-serde": "^2.0.12",
+        "@smithy/middleware-stack": "^2.0.6",
+        "@smithy/node-config-provider": "^2.1.3",
+        "@smithy/node-http-handler": "^2.1.8",
+        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/smithy-client": "^2.1.12",
+        "@smithy/types": "^2.4.0",
+        "@smithy/url-parser": "^2.0.12",
+        "@smithy/util-base64": "^2.0.0",
         "@smithy/util-body-length-browser": "^2.0.0",
         "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.19",
-        "@smithy/util-defaults-mode-node": "^2.0.25",
-        "@smithy/util-endpoints": "^1.0.4",
-        "@smithy/util-retry": "^2.0.6",
-        "@smithy/util-utf8": "^2.0.2",
+        "@smithy/util-defaults-mode-browser": "^2.0.16",
+        "@smithy/util-defaults-mode-node": "^2.0.21",
+        "@smithy/util-retry": "^2.0.5",
+        "@smithy/util-utf8": "^2.0.0",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
       },
@@ -342,26 +363,49 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/core": {
-      "version": "3.451.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.451.0.tgz",
-      "integrity": "sha512-SamWW2zHEf1ZKe3j1w0Piauryl8BQIlej0TBS18A4ACzhjhWXhCs13bO1S88LvPR5mBFXok3XOT6zPOnKDFktw==",
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/types": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
+      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
       "dependencies": {
-        "@smithy/smithy-client": "^2.1.15",
+        "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.460.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.460.0.tgz",
-      "integrity": "sha512-WWdaRJFuYRc2Ue9NKDy2NIf8pQRNx/QRVmrsk6EkIID8uWlQIOePk3SWTVV0TZIyPrbfSEaSnJRZoShphJ6PAg==",
+    "node_modules/@aws-sdk/core": {
+      "version": "3.436.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.436.0.tgz",
+      "integrity": "sha512-vX5/LjXvCejC2XUY6TSg1oozjqK6BvkE75t0ys9dgqyr5PlZyZksMoeAFHUlj0sCjhT3ziWCujP1oiSpPWY9hg==",
       "dependencies": {
-        "@aws-sdk/types": "3.460.0",
+        "@smithy/smithy-client": "^2.1.12"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.433.0.tgz",
+      "integrity": "sha512-Vl7Qz5qYyxBurMn6hfSiNJeUHSqfVUlMt0C1Bds3tCkl3IzecRWwyBOlxtxO3VCrgVeW3HqswLzCvhAFzPH6nQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.433.0",
         "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.5.0",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env/node_modules/@aws-sdk/types": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
+      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -369,19 +413,31 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.460.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.460.0.tgz",
-      "integrity": "sha512-1IEUmyaWzt2M3mONO8QyZtPy0f9ccaEjCo48ZQLgptWxUI+Ohga9gPK0mqu1kTJOjv4JJGACYHzLwEnnpltGlA==",
+      "version": "3.437.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.437.0.tgz",
+      "integrity": "sha512-UybiJxYPvdwok5OcI9LakaHmaWZBdkX0gY8yU2n7TomYgWOwDJ88MpQgjXUJJ249PH+9/+How5H3vnFp0xJ0uQ==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.460.0",
-        "@aws-sdk/credential-provider-process": "3.460.0",
-        "@aws-sdk/credential-provider-sso": "3.460.0",
-        "@aws-sdk/credential-provider-web-identity": "3.460.0",
-        "@aws-sdk/types": "3.460.0",
+        "@aws-sdk/credential-provider-env": "3.433.0",
+        "@aws-sdk/credential-provider-process": "3.433.0",
+        "@aws-sdk/credential-provider-sso": "3.437.0",
+        "@aws-sdk/credential-provider-web-identity": "3.433.0",
+        "@aws-sdk/types": "3.433.0",
         "@smithy/credential-provider-imds": "^2.0.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.5.0",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/types": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
+      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -389,20 +445,32 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.460.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.460.0.tgz",
-      "integrity": "sha512-PbPo92WIgNlF6V4eWKehYGYjTqf0gU9vr09LeQUc3bTm1DJhJw1j+HU/3PfQ8LwTkBQePO7MbJ5A2n6ckMwfMg==",
+      "version": "3.437.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.437.0.tgz",
+      "integrity": "sha512-FMtgEe/me68xZQsymEpMcw7OuuiHaHx/Tp5EqZP5FC0Yv1yX3qr/ncIWU2zY3a9K0iLERmzQI1g3CMd8r4sy8A==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.460.0",
-        "@aws-sdk/credential-provider-ini": "3.460.0",
-        "@aws-sdk/credential-provider-process": "3.460.0",
-        "@aws-sdk/credential-provider-sso": "3.460.0",
-        "@aws-sdk/credential-provider-web-identity": "3.460.0",
-        "@aws-sdk/types": "3.460.0",
+        "@aws-sdk/credential-provider-env": "3.433.0",
+        "@aws-sdk/credential-provider-ini": "3.437.0",
+        "@aws-sdk/credential-provider-process": "3.433.0",
+        "@aws-sdk/credential-provider-sso": "3.437.0",
+        "@aws-sdk/credential-provider-web-identity": "3.433.0",
+        "@aws-sdk/types": "3.433.0",
         "@smithy/credential-provider-imds": "^2.0.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.5.0",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/types": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
+      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -410,14 +478,26 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.460.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.460.0.tgz",
-      "integrity": "sha512-ng+0FMc4EaxLAwdttCwf2nzNf4AgcqAHZ8pKXUf8qF/KVkoyTt3UZKW7P2FJI01zxwP+V4yAwVt95PBUKGn4YQ==",
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.433.0.tgz",
+      "integrity": "sha512-W7FcGlQjio9Y/PepcZGRyl5Bpwb0uWU7qIUCh+u4+q2mW4D5ZngXg8V/opL9/I/p4tUH9VXZLyLGwyBSkdhL+A==",
       "dependencies": {
-        "@aws-sdk/types": "3.460.0",
+        "@aws-sdk/types": "3.433.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.5.0",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process/node_modules/@aws-sdk/types": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
+      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -425,16 +505,28 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.460.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.460.0.tgz",
-      "integrity": "sha512-KnrQieOw17+aHEzE3SwfxjeSQ5ZTe2HeAzxkaZF++GxhNul/PkVnLzjGpIuB9bn71T9a2oNfG3peDUA+m2l2kw==",
+      "version": "3.437.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.437.0.tgz",
+      "integrity": "sha512-kijtnyyA6/+ipOef4KACsLDUTFWDZ97DSWKU0hJFyGEfelaon6o7NNVufuVOWrBNyklNWZqvPLuwWWQCxb6fuQ==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.460.0",
-        "@aws-sdk/token-providers": "3.460.0",
-        "@aws-sdk/types": "3.460.0",
+        "@aws-sdk/client-sso": "3.437.0",
+        "@aws-sdk/token-providers": "3.437.0",
+        "@aws-sdk/types": "3.433.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.5.0",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/types": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
+      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -442,13 +534,25 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.460.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.460.0.tgz",
-      "integrity": "sha512-7OeaZgC3HmJZGE0I0ZiKInUMF2LyA0IZiW85AYFnAZzAIfv1cXk/1UnDAoFIQhOZfnUBXivStagz892s480ryw==",
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.433.0.tgz",
+      "integrity": "sha512-RlwjP1I5wO+aPpwyCp23Mk8nmRbRL33hqRASy73c4JA2z2YiRua+ryt6MalIxehhwQU6xvXUKulJnPG9VaMFZg==",
       "dependencies": {
-        "@aws-sdk/types": "3.460.0",
+        "@aws-sdk/types": "3.433.0",
         "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.5.0",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@aws-sdk/types": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
+      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -456,16 +560,28 @@
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.460.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.460.0.tgz",
-      "integrity": "sha512-AmrCDT/r+m7q3OogZ3UeWpVdllMeR4Wdo+3YEfefPfcZc6SilnP2uCBUHletxbw3tXhNt56bUMUzQ+SUhyuUmA==",
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.433.0.tgz",
+      "integrity": "sha512-Lk1xIu2tWTRa1zDw5hCF1RrpWQYSodUhrS/q3oKz8IAoFqEy+lNaD5jx+fycuZb5EkE4IzWysT+8wVkd0mAnOg==",
       "dependencies": {
-        "@aws-sdk/types": "3.460.0",
+        "@aws-sdk/types": "3.433.0",
         "@aws-sdk/util-arn-parser": "3.310.0",
-        "@smithy/node-config-provider": "^2.1.5",
-        "@smithy/protocol-http": "^3.0.9",
-        "@smithy/types": "^2.5.0",
+        "@smithy/node-config-provider": "^2.1.3",
+        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/types": "^2.4.0",
         "@smithy/util-config-provider": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@aws-sdk/types": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
+      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -473,13 +589,25 @@
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.460.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.460.0.tgz",
-      "integrity": "sha512-8VxMFTR+IszcMZLUZvxVCBOO1CUBmIWmDIQKd7w/U9xyMEXmBA0cx6ZEfMOIZF9NNh9OGCzTvwK+++8OTGBwAw==",
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.433.0.tgz",
+      "integrity": "sha512-Uq2rPIsjz0CR2sulM/HyYr5WiqiefrSRLdwUZuA7opxFSfE808w5DBWSprHxbH3rbDSQR4nFiOiVYIH8Eth7nA==",
       "dependencies": {
-        "@aws-sdk/types": "3.460.0",
-        "@smithy/protocol-http": "^3.0.9",
-        "@smithy/types": "^2.5.0",
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue/node_modules/@aws-sdk/types": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
+      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -487,17 +615,29 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.461.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.461.0.tgz",
-      "integrity": "sha512-MNY7xMl2Qzoinj6Pos23TgD+WQtC9/G/VkNW/v8Ky5faRAt7bbS+ZEkkK3KcCrjnb8x4Bl/FzYNTCZRzRoQOtA==",
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.433.0.tgz",
+      "integrity": "sha512-Ptssx373+I7EzFUWjp/i/YiNFt6I6sDuRHz6DOUR9nmmRTlHHqmdcBXlJL2d9wwFxoBRCN8/PXGsTc/DJ4c95Q==",
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
         "@aws-crypto/crc32c": "3.0.0",
-        "@aws-sdk/types": "3.460.0",
+        "@aws-sdk/types": "3.433.0",
         "@smithy/is-array-buffer": "^2.0.0",
-        "@smithy/protocol-http": "^3.0.9",
-        "@smithy/types": "^2.5.0",
-        "@smithy/util-utf8": "^2.0.2",
+        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/types": "^2.4.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/types": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
+      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -505,13 +645,25 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.460.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.460.0.tgz",
-      "integrity": "sha512-qBeDyuJkEuHe87Xk6unvFO9Zg5j6zM8bQOOZITocTLfu9JN0u5V4GQ/yopvpv+nQHmC/MGr0G7p+kIXMrg/Q2A==",
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.433.0.tgz",
+      "integrity": "sha512-mBTq3UWv1UzeHG+OfUQ2MB/5GEkt5LTKFaUqzL7ESwzW8XtpBgXnjZvIwu3Vcd3sEetMwijwaGiJhY0ae/YyaA==",
       "dependencies": {
-        "@aws-sdk/types": "3.460.0",
-        "@smithy/protocol-http": "^3.0.9",
-        "@smithy/types": "^2.5.0",
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header/node_modules/@aws-sdk/types": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
+      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -519,12 +671,24 @@
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.461.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.461.0.tgz",
-      "integrity": "sha512-dibimciNOV2kuhBBmHbS+29X559xNw4BdZviGzjGAQPkqPx+7Adgvp5BHqSDgh7FIJpgN2+QGbrubIQ+V1Bn4A==",
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.433.0.tgz",
+      "integrity": "sha512-2YD860TGntwZifIUbxm+lFnNJJhByR/RB/+fV1I8oGKg+XX2rZU+94pRfHXRywoZKlCA0L+LGDA1I56jxrB9sw==",
       "dependencies": {
-        "@aws-sdk/types": "3.460.0",
-        "@smithy/types": "^2.5.0",
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint/node_modules/@aws-sdk/types": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
+      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -532,12 +696,24 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.460.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.460.0.tgz",
-      "integrity": "sha512-w2AJ6HOJ+Ggx9+VDKuWBHk5S0ZxYEo2EY2IFh0qtCQ1RDix/ur1QEzOOL5vNjHlZKPv/dseIwhgsTCac8UHXbQ==",
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.433.0.tgz",
+      "integrity": "sha512-We346Fb5xGonTGVZC9Nvqtnqy74VJzYuTLLiuuftA5sbNzftBDy/22QCfvYSTOAl3bvif+dkDUzQY2ihc5PwOQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.460.0",
-        "@smithy/types": "^2.5.0",
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger/node_modules/@aws-sdk/types": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
+      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -545,13 +721,25 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.460.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.460.0.tgz",
-      "integrity": "sha512-wmzm1/2NzpcCVCAsGqqiTBK+xNyLmQwTOq63rcW6eeq6gYOO0cyTZROOkVRrrsKWPBigrSFFHvDrEvonOMtKAg==",
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.433.0.tgz",
+      "integrity": "sha512-HEvYC9PQlWY/ccUYtLvAlwwf1iCif2TSAmLNr3YTBRVa98x6jKL0hlCrHWYklFeqOGSKy6XhE+NGJMUII0/HaQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.460.0",
-        "@smithy/protocol-http": "^3.0.9",
-        "@smithy/types": "^2.5.0",
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@aws-sdk/types": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
+      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -559,18 +747,27 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.461.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.461.0.tgz",
-      "integrity": "sha512-sOFUBWROq0xQxNoXp+3eepXrUAuMc/JPH+sI/r5QOznk7JVemYoBj99lknbTzJ4ssSK0yVrSUxxwGiGvDQb0Gg==",
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.433.0.tgz",
+      "integrity": "sha512-mkn3DiSuMVh4NTLsduC42Av+ApcOor52LMoQY0Wc6M5Mx7Xd05U+G1j8sjI9n/1bs5cZ/PoeRYJ/9bL1Xxznnw==",
       "dependencies": {
-        "@aws-sdk/types": "3.460.0",
+        "@aws-sdk/types": "3.433.0",
         "@aws-sdk/util-arn-parser": "3.310.0",
-        "@smithy/node-config-provider": "^2.1.5",
-        "@smithy/protocol-http": "^3.0.9",
-        "@smithy/signature-v4": "^2.0.0",
-        "@smithy/smithy-client": "^2.1.15",
-        "@smithy/types": "^2.5.0",
-        "@smithy/util-config-provider": "^2.0.0",
+        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/smithy-client": "^2.1.12",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/types": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
+      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -578,13 +775,25 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.461.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.461.0.tgz",
-      "integrity": "sha512-sgNxkwKdJ/NZm7SJZBnbYPkbspmzn3lDyRSJH7PTCvyzDBzY2PB6yS/dfnGkitR+PYwromuOYMha37W4su2SOw==",
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.433.0.tgz",
+      "integrity": "sha512-ORYbJnBejUyonFl5FwIqhvI3Cq6sAp9j+JpkKZtFNma9tFPdrhmYgfCeNH32H/wGTQV/tUoQ3luh0gA4cuk6DA==",
       "dependencies": {
-        "@aws-sdk/middleware-signing": "3.461.0",
-        "@aws-sdk/types": "3.460.0",
-        "@smithy/types": "^2.5.0",
+        "@aws-sdk/middleware-signing": "3.433.0",
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@aws-sdk/types": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
+      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -592,16 +801,28 @@
       }
     },
     "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.461.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.461.0.tgz",
-      "integrity": "sha512-aM/7VupHlsgeRG1UZSAQMWJX+2Jam4GG8ZGVAbLfBr9yh9cBwnUUndpUpYI9rU7atA8n+vISr162EbR7WTiFhQ==",
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.433.0.tgz",
+      "integrity": "sha512-jxPvt59NZo/epMNLNTu47ikmP8v0q217I6bQFGJG7JVFnfl36zDktMwGw+0xZR80qiK47/2BWrNpta61Zd2FxQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.460.0",
+        "@aws-sdk/types": "3.433.0",
         "@smithy/property-provider": "^2.0.0",
-        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/protocol-http": "^3.0.8",
         "@smithy/signature-v4": "^2.0.0",
-        "@smithy/types": "^2.5.0",
-        "@smithy/util-middleware": "^2.0.6",
+        "@smithy/types": "^2.4.0",
+        "@smithy/util-middleware": "^2.0.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing/node_modules/@aws-sdk/types": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
+      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -609,12 +830,24 @@
       }
     },
     "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.460.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.460.0.tgz",
-      "integrity": "sha512-1PSCmkq9BRX8isxyDyf785xvjldtwhdUzI+37oZ1qfDXGmRyB+KjtRBNnz5Fz+VSiOfVzfhp3sjrc4fs4BfJ0w==",
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.433.0.tgz",
+      "integrity": "sha512-2AMaPx0kYfCiekxoL7aqFqSSoA9du+yI4zefpQNLr+1cZOerYiDxdsZ4mbqStR1CVFaX6U6hrYokXzjInsvETw==",
       "dependencies": {
-        "@aws-sdk/types": "3.460.0",
-        "@smithy/types": "^2.5.0",
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec/node_modules/@aws-sdk/types": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
+      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -622,14 +855,26 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.460.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.460.0.tgz",
-      "integrity": "sha512-0gBSOCr+RtwRUCSRLn9H3RVnj9ercvk/QKTHIr33CgfEdyZtIGpHWUSs6uqiQydPTRzjCm5SfUa6ESGhRVMM6A==",
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.433.0.tgz",
+      "integrity": "sha512-jMgA1jHfisBK4oSjMKrtKEZf0sl2vzADivkFmyZFzORpSZxBnF6hC21RjaI+70LJLcc9rSCzLgcoz5lHb9LLDg==",
       "dependencies": {
-        "@aws-sdk/types": "3.460.0",
-        "@aws-sdk/util-endpoints": "3.460.0",
-        "@smithy/protocol-http": "^3.0.9",
-        "@smithy/types": "^2.5.0",
+        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/util-endpoints": "3.433.0",
+        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/types": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
+      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -637,14 +882,14 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.451.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.451.0.tgz",
-      "integrity": "sha512-3iMf4OwzrFb4tAAmoROXaiORUk2FvSejnHIw/XHvf/jjR4EqGGF95NZP/n/MeFZMizJWVssrwS412GmoEyoqhg==",
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.433.0.tgz",
+      "integrity": "sha512-xpjRjCZW+CDFdcMmmhIYg81ST5UAnJh61IHziQEk0FXONrg4kjyYPZAOjEdzXQ+HxJQuGQLKPhRdzxmQnbX7pg==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.5",
-        "@smithy/types": "^2.5.0",
+        "@smithy/node-config-provider": "^2.1.3",
+        "@smithy/types": "^2.4.0",
         "@smithy/util-config-provider": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.6",
+        "@smithy/util-middleware": "^2.0.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -652,15 +897,26 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.461.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.461.0.tgz",
-      "integrity": "sha512-9tsdJ5KMPZzJN1x28AZKoS9J3xfwftFwutqcU1qsXXeouck0CztLfX+wr3etO4acPQO2zU305fnR2ulSsnns4g==",
+      "version": "3.437.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.437.0.tgz",
+      "integrity": "sha512-MmrqudssOs87JgVg7HGVdvJws/t4kcOrJJd+975ki+DPeSoyK2U4zBDfDkJ+n0tFuZBs3sLwLh0QXE7BV28rRA==",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "3.461.0",
-        "@aws-sdk/types": "3.460.0",
-        "@smithy/protocol-http": "^3.0.9",
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/protocol-http": "^3.0.8",
         "@smithy/signature-v4": "^2.0.0",
-        "@smithy/types": "^2.5.0",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/types": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
+      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -668,46 +924,57 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.460.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.460.0.tgz",
-      "integrity": "sha512-EvSIPMI1gXk3gEkdtbZCW+p3Bjmt2gOR1m7ibQD7qLj4l0dKXhp4URgTqB1ExH3S4qUq0M/XSGKbGLZpvunHNg==",
+      "version": "3.437.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.437.0.tgz",
+      "integrity": "sha512-nV9qIuG0+6XJb7hWpCC+/K7RoY3PZUWndP8BRQv7PQhhpd8tG/I5Kxb0V83h2XFBXyyjnv0aOHO8ehz3Kfcv2Q==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/middleware-host-header": "3.460.0",
-        "@aws-sdk/middleware-logger": "3.460.0",
-        "@aws-sdk/middleware-recursion-detection": "3.460.0",
-        "@aws-sdk/middleware-user-agent": "3.460.0",
-        "@aws-sdk/region-config-resolver": "3.451.0",
-        "@aws-sdk/types": "3.460.0",
-        "@aws-sdk/util-endpoints": "3.460.0",
-        "@aws-sdk/util-user-agent-browser": "3.460.0",
-        "@aws-sdk/util-user-agent-node": "3.460.0",
-        "@smithy/config-resolver": "^2.0.18",
-        "@smithy/fetch-http-handler": "^2.2.6",
-        "@smithy/hash-node": "^2.0.15",
-        "@smithy/invalid-dependency": "^2.0.13",
-        "@smithy/middleware-content-length": "^2.0.15",
-        "@smithy/middleware-endpoint": "^2.2.0",
-        "@smithy/middleware-retry": "^2.0.20",
-        "@smithy/middleware-serde": "^2.0.13",
-        "@smithy/middleware-stack": "^2.0.7",
-        "@smithy/node-config-provider": "^2.1.5",
-        "@smithy/node-http-handler": "^2.1.9",
+        "@aws-sdk/middleware-host-header": "3.433.0",
+        "@aws-sdk/middleware-logger": "3.433.0",
+        "@aws-sdk/middleware-recursion-detection": "3.433.0",
+        "@aws-sdk/middleware-user-agent": "3.433.0",
+        "@aws-sdk/region-config-resolver": "3.433.0",
+        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/util-endpoints": "3.433.0",
+        "@aws-sdk/util-user-agent-browser": "3.433.0",
+        "@aws-sdk/util-user-agent-node": "3.437.0",
+        "@smithy/config-resolver": "^2.0.16",
+        "@smithy/fetch-http-handler": "^2.2.4",
+        "@smithy/hash-node": "^2.0.12",
+        "@smithy/invalid-dependency": "^2.0.12",
+        "@smithy/middleware-content-length": "^2.0.14",
+        "@smithy/middleware-endpoint": "^2.1.3",
+        "@smithy/middleware-retry": "^2.0.18",
+        "@smithy/middleware-serde": "^2.0.12",
+        "@smithy/middleware-stack": "^2.0.6",
+        "@smithy/node-config-provider": "^2.1.3",
+        "@smithy/node-http-handler": "^2.1.8",
         "@smithy/property-provider": "^2.0.0",
-        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/protocol-http": "^3.0.8",
         "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/smithy-client": "^2.1.15",
-        "@smithy/types": "^2.5.0",
-        "@smithy/url-parser": "^2.0.13",
-        "@smithy/util-base64": "^2.0.1",
+        "@smithy/smithy-client": "^2.1.12",
+        "@smithy/types": "^2.4.0",
+        "@smithy/url-parser": "^2.0.12",
+        "@smithy/util-base64": "^2.0.0",
         "@smithy/util-body-length-browser": "^2.0.0",
         "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.19",
-        "@smithy/util-defaults-mode-node": "^2.0.25",
-        "@smithy/util-endpoints": "^1.0.4",
-        "@smithy/util-retry": "^2.0.6",
-        "@smithy/util-utf8": "^2.0.2",
+        "@smithy/util-defaults-mode-browser": "^2.0.16",
+        "@smithy/util-defaults-mode-node": "^2.0.21",
+        "@smithy/util-retry": "^2.0.5",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/types": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
+      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -738,12 +1005,23 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.460.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.460.0.tgz",
-      "integrity": "sha512-myH6kM5WP4IWULHDHMYf2Q+BCYVGlzqJgiBmO10kQEtJSeAGZZ49eoFFYgKW8ZAYB5VnJ+XhXVB1TRA+vR4l5A==",
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.433.0.tgz",
+      "integrity": "sha512-LFNUh9FH7RMtYjSjPGz9lAJQMzmJ3RcXISzc5X5k2R/9mNwMK7y1k2VAfvx+RbuDbll6xwsXlgv6QHcxVdF2zw==",
       "dependencies": {
-        "@aws-sdk/types": "3.460.0",
-        "@smithy/util-endpoints": "^1.0.4",
+        "@aws-sdk/types": "3.433.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints/node_modules/@aws-sdk/types": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
+      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -762,24 +1040,36 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.460.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.460.0.tgz",
-      "integrity": "sha512-FRCzW+TyjKnvxsargPVrjayBfp/rvObYHZyZ2OSqrVw8lkkPCb4e/WZOeIiXZuhdhhoah7wMuo6zGwtFF3bYKg==",
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.433.0.tgz",
+      "integrity": "sha512-2Cf/Lwvxbt5RXvWFXrFr49vXv0IddiUwrZoAiwhDYxvsh+BMnh+NUFot+ZQaTrk/8IPZVDeLPWZRdVy00iaVXQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.460.0",
-        "@smithy/types": "^2.5.0",
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/types": "^2.4.0",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       }
     },
-    "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.460.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.460.0.tgz",
-      "integrity": "sha512-+kSoR9ABGpJ5Xc7v0VwpgTQbgyI4zuezC8K4pmKAGZsSsVWg4yxptoy2bDqoFL7qfRlWviMVTkQRMvR4D44WxA==",
+    "node_modules/@aws-sdk/util-user-agent-browser/node_modules/@aws-sdk/types": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
+      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
       "dependencies": {
-        "@aws-sdk/types": "3.460.0",
-        "@smithy/node-config-provider": "^2.1.5",
-        "@smithy/types": "^2.5.0",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.437.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.437.0.tgz",
+      "integrity": "sha512-JVEcvWaniamtYVPem4UthtCNoTBCfFTwYj7Y3CrWZ2Qic4TqrwLkAfaBGtI2TGrhIClVr77uzLI6exqMTN7orA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/node-config-provider": "^2.1.3",
+        "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -792,6 +1082,18 @@
         "aws-crt": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node/node_modules/@aws-sdk/types": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
+      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-utf8-browser": {
@@ -1959,11 +2261,11 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.14.tgz",
-      "integrity": "sha512-zXtteuYLWbSXnzI3O6xq3FYvigYZFW8mdytGibfarLL2lxHto9L3ILtGVnVGmFZa7SDh62l39EnU5hesLN87Fw==",
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.15.tgz",
+      "integrity": "sha512-JkS36PIS3/UCbq/MaozzV7jECeL+BTt4R75bwY8i+4RASys4xOyUS1HsRyUNSqUXFP4QyCz5aNnh3ltuaxv+pw==",
       "dependencies": {
-        "@smithy/types": "^2.6.0",
+        "@smithy/types": "^2.7.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1988,14 +2290,14 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.19.tgz",
-      "integrity": "sha512-JsghnQ5zjWmjEVY8TFOulLdEOCj09SjRLugrHlkPZTIBBm7PQitCFVLThbsKPZQOP7N3ME1DU1nKUc1UaVnBog==",
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.21.tgz",
+      "integrity": "sha512-rlLIGT+BeqjnA6C2FWumPRJS1UW07iU5ZxDHtFuyam4W65gIaOFMjkB90ofKCIh+0mLVQrQFrl/VLtQT/6FWTA==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.6",
-        "@smithy/types": "^2.6.0",
+        "@smithy/node-config-provider": "^2.1.8",
+        "@smithy/types": "^2.7.0",
         "@smithy/util-config-provider": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.7",
+        "@smithy/util-middleware": "^2.0.8",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2003,14 +2305,14 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.1.2.tgz",
-      "integrity": "sha512-Y62jBWdoLPSYjr9fFvJf+KwTa1EunjVr6NryTEWCnwIY93OJxwV4t0qxjwdPl/XMsUkq79ppNJSEQN6Ohnhxjw==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.1.4.tgz",
+      "integrity": "sha512-cwPJN1fa1YOQzhBlTXRavABEYRRchci1X79QRwzaNLySnIMJfztyv1Zkst0iZPLMnpn8+CnHu3wOHS11J5Dr3A==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.6",
-        "@smithy/property-provider": "^2.0.15",
-        "@smithy/types": "^2.6.0",
-        "@smithy/url-parser": "^2.0.14",
+        "@smithy/node-config-provider": "^2.1.8",
+        "@smithy/property-provider": "^2.0.16",
+        "@smithy/types": "^2.7.0",
+        "@smithy/url-parser": "^2.0.15",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2018,12 +2320,12 @@
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.14.tgz",
-      "integrity": "sha512-g/OU/MeWGfHDygoXgMWfG/Xb0QqDnAGcM9t2FRrVAhleXYRddGOEnfanR5cmHgB9ue52MJsyorqFjckzXsylaA==",
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.15.tgz",
+      "integrity": "sha512-crjvz3j1gGPwA0us6cwS7+5gAn35CTmqu/oIxVbYJo2Qm/sGAye6zGJnMDk3BKhWZw5kcU1G4MxciTkuBpOZPg==",
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
-        "@smithy/types": "^2.6.0",
+        "@smithy/types": "^2.7.0",
         "@smithy/util-hex-encoding": "^2.0.0",
         "tslib": "^2.5.0"
       }
@@ -2080,13 +2382,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.2.7.tgz",
-      "integrity": "sha512-iSDBjxuH9TgrtMYAr7j5evjvkvgwLY3y+9D547uep+JNkZ1ZT+BaeU20j6I/bO/i26ilCWFImrlXTPsfQtZdIQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.3.1.tgz",
+      "integrity": "sha512-6MNk16fqb8EwcYY8O8WxB3ArFkLZ2XppsSNo1h7SQcFdDDwIumiJeO6wRzm7iB68xvsOQzsdQKbdtTieS3hfSQ==",
       "dependencies": {
-        "@smithy/protocol-http": "^3.0.10",
-        "@smithy/querystring-builder": "^2.0.14",
-        "@smithy/types": "^2.6.0",
+        "@smithy/protocol-http": "^3.0.11",
+        "@smithy/querystring-builder": "^2.0.15",
+        "@smithy/types": "^2.7.0",
         "@smithy/util-base64": "^2.0.1",
         "tslib": "^2.5.0"
       }
@@ -2103,11 +2405,11 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.16.tgz",
-      "integrity": "sha512-Wbi9A0PacMYUOwjAulQP90Wl3mQ6NDwnyrZQzFjDz+UzjXOSyQMgBrTkUBz+pVoYVlX3DUu24gWMZBcit+wOGg==",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.17.tgz",
+      "integrity": "sha512-Il6WuBcI1nD+e2DM7tTADMf01wEPGK8PAhz4D+YmDUVaoBqlA+CaH2uDJhiySifmuKBZj748IfygXty81znKhw==",
       "dependencies": {
-        "@smithy/types": "^2.6.0",
+        "@smithy/types": "^2.7.0",
         "@smithy/util-buffer-from": "^2.0.0",
         "@smithy/util-utf8": "^2.0.2",
         "tslib": "^2.5.0"
@@ -2130,11 +2432,11 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.14.tgz",
-      "integrity": "sha512-d8ohpwZo9RzTpGlAfsWtfm1SHBSU7+N4iuZ6MzR10xDTujJJWtmXYHK1uzcr7rggbpUTaWyHpPFgnf91q0EFqQ==",
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.15.tgz",
+      "integrity": "sha512-dlEKBFFwVfzA5QroHlBS94NpgYjXhwN/bFfun+7w3rgxNvVy79SK0w05iGc7UAeC5t+D7gBxrzdnD6hreZnDVQ==",
       "dependencies": {
-        "@smithy/types": "^2.6.0",
+        "@smithy/types": "^2.7.0",
         "tslib": "^2.5.0"
       }
     },
@@ -2160,12 +2462,12 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.16.tgz",
-      "integrity": "sha512-9ddDia3pp1d3XzLXKcm7QebGxLq9iwKf+J1LapvlSOhpF8EM9SjMeSrMOOFgG+2TfW5K3+qz4IAJYYm7INYCng==",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.17.tgz",
+      "integrity": "sha512-OyadvMcKC7lFXTNBa8/foEv7jOaqshQZkjWS9coEXPRZnNnihU/Ls+8ZuJwGNCOrN2WxXZFmDWhegbnM4vak8w==",
       "dependencies": {
-        "@smithy/protocol-http": "^3.0.10",
-        "@smithy/types": "^2.6.0",
+        "@smithy/protocol-http": "^3.0.11",
+        "@smithy/types": "^2.7.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2173,16 +2475,16 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.2.1.tgz",
-      "integrity": "sha512-dVDS7HNJl/wb0lpByXor6whqDbb1YlLoaoWYoelyYzLHioXOE7y/0iDwJWtDcN36/tVCw9EPBFZ3aans84jLpg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.2.3.tgz",
+      "integrity": "sha512-nYfxuq0S/xoAjdLbyn1ixeVB6cyH9wYCMtbbOCpcCRYR5u2mMtqUtVjjPAZ/DIdlK3qe0tpB0Q76szFGNuz+kQ==",
       "dependencies": {
-        "@smithy/middleware-serde": "^2.0.14",
-        "@smithy/node-config-provider": "^2.1.6",
-        "@smithy/shared-ini-file-loader": "^2.2.5",
-        "@smithy/types": "^2.6.0",
-        "@smithy/url-parser": "^2.0.14",
-        "@smithy/util-middleware": "^2.0.7",
+        "@smithy/middleware-serde": "^2.0.15",
+        "@smithy/node-config-provider": "^2.1.8",
+        "@smithy/shared-ini-file-loader": "^2.2.7",
+        "@smithy/types": "^2.7.0",
+        "@smithy/url-parser": "^2.0.15",
+        "@smithy/util-middleware": "^2.0.8",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2190,16 +2492,17 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "2.0.21",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.21.tgz",
-      "integrity": "sha512-EZS1EXv1k6IJX6hyu/0yNQuPcPaXwG8SWljQHYueyRbOxmqYgoWMWPtfZj0xRRQ4YtLawQSpBgAeiJltq8/MPw==",
+      "version": "2.0.24",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.24.tgz",
+      "integrity": "sha512-q2SvHTYu96N7lYrn3VSuX3vRpxXHR/Cig6MJpGWxd0BWodUQUWlKvXpWQZA+lTaFJU7tUvpKhRd4p4MU3PbeJg==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.6",
-        "@smithy/protocol-http": "^3.0.10",
-        "@smithy/service-error-classification": "^2.0.7",
-        "@smithy/types": "^2.6.0",
-        "@smithy/util-middleware": "^2.0.7",
-        "@smithy/util-retry": "^2.0.7",
+        "@smithy/node-config-provider": "^2.1.8",
+        "@smithy/protocol-http": "^3.0.11",
+        "@smithy/service-error-classification": "^2.0.8",
+        "@smithy/smithy-client": "^2.1.18",
+        "@smithy/types": "^2.7.0",
+        "@smithy/util-middleware": "^2.0.8",
+        "@smithy/util-retry": "^2.0.8",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       },
@@ -2207,20 +2510,12 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@smithy/middleware-retry/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@smithy/middleware-serde": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.14.tgz",
-      "integrity": "sha512-hFi3FqoYWDntCYA2IGY6gJ6FKjq2gye+1tfxF2HnIJB5uW8y2DhpRNBSUMoqP+qvYzRqZ6ntv4kgbG+o3pX57g==",
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.15.tgz",
+      "integrity": "sha512-FOZRFk/zN4AT4wzGuBY+39XWe+ZnCFd0gZtyw3f9Okn2CJPixl9GyWe98TIaljeZdqWkgrzGyPre20AcW2UMHQ==",
       "dependencies": {
-        "@smithy/types": "^2.6.0",
+        "@smithy/types": "^2.7.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2228,11 +2523,11 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.8.tgz",
-      "integrity": "sha512-7/N59j0zWqVEKExJcA14MrLDZ/IeN+d6nbkN8ucs+eURyaDUXWYlZrQmMOd/TyptcQv0+RDlgag/zSTTV62y/Q==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.9.tgz",
+      "integrity": "sha512-bCB5dUtGQ5wh7QNL2ELxmDc6g7ih7jWU3Kx6MYH1h4mZbv9xL3WyhKHojRltThCB1arLPyTUFDi+x6fB/oabtA==",
       "dependencies": {
-        "@smithy/types": "^2.6.0",
+        "@smithy/types": "^2.7.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2240,13 +2535,13 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.1.6.tgz",
-      "integrity": "sha512-HLqTs6O78m3M3z1cPLFxddxhEPv5MkVatfPuxoVO3A+cHZanNd/H5I6btcdHy6N2CB1MJ/lihJC92h30SESsBA==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.1.8.tgz",
+      "integrity": "sha512-+w26OKakaBUGp+UG+dxYZtFb5fs3tgHg3/QrRrmUZj+rl3cIuw840vFUXX35cVPTUCQIiTqmz7CpVF7+hdINdQ==",
       "dependencies": {
-        "@smithy/property-provider": "^2.0.15",
-        "@smithy/shared-ini-file-loader": "^2.2.5",
-        "@smithy/types": "^2.6.0",
+        "@smithy/property-provider": "^2.0.16",
+        "@smithy/shared-ini-file-loader": "^2.2.7",
+        "@smithy/types": "^2.7.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2254,14 +2549,14 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.10.tgz",
-      "integrity": "sha512-lkALAwtN6odygIM4nB8aHDahINM6WXXjNrZmWQAh0RSossySRT2qa31cFv0ZBuAYVWeprskRk13AFvvLmf1WLw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.2.1.tgz",
+      "integrity": "sha512-8iAKQrC8+VFHPAT8pg4/j6hlsTQh+NKOWlctJBrYtQa4ExcxX7aSg3vdQ2XLoYwJotFUurg/NLqFCmZaPRrogw==",
       "dependencies": {
-        "@smithy/abort-controller": "^2.0.14",
-        "@smithy/protocol-http": "^3.0.10",
-        "@smithy/querystring-builder": "^2.0.14",
-        "@smithy/types": "^2.6.0",
+        "@smithy/abort-controller": "^2.0.15",
+        "@smithy/protocol-http": "^3.0.11",
+        "@smithy/querystring-builder": "^2.0.15",
+        "@smithy/types": "^2.7.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2269,11 +2564,11 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.15.tgz",
-      "integrity": "sha512-YbRFBn8oiiC3o1Kn3a4KjGa6k47rCM9++5W9cWqYn9WnkyH+hBWgfJAckuxpyA2Hq6Ys4eFrWzXq6fqHEw7iew==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.16.tgz",
+      "integrity": "sha512-28Ky0LlOqtEjwg5CdHmwwaDRHcTWfPRzkT6HrhwOSRS2RryAvuDfJrZpM+BMcrdeCyEg1mbcgIMoqTla+rdL8Q==",
       "dependencies": {
-        "@smithy/types": "^2.6.0",
+        "@smithy/types": "^2.7.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2281,11 +2576,11 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.10.tgz",
-      "integrity": "sha512-6+tjNk7rXW7YTeGo9qwxXj/2BFpJTe37kTj3EnZCoX/nH+NP/WLA7O83fz8XhkGqsaAhLUPo/bB12vvd47nsmg==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.11.tgz",
+      "integrity": "sha512-3ziB8fHuXIRamV/akp/sqiWmNPR6X+9SB8Xxnozzj+Nq7hSpyKdFHd1FLpBkgfGFUTzzcBJQlDZPSyxzmdcx5A==",
       "dependencies": {
-        "@smithy/types": "^2.6.0",
+        "@smithy/types": "^2.7.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2293,11 +2588,11 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.14.tgz",
-      "integrity": "sha512-lQ4pm9vTv9nIhl5jt6uVMPludr6syE2FyJmHsIJJuOD7QPIJnrf9HhUGf1iHh9KJ4CUv21tpOU3X6s0rB6uJ0g==",
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.15.tgz",
+      "integrity": "sha512-e1q85aT6HutvouOdN+dMsN0jcdshp50PSCvxDvo6aIM57LqeXimjfONUEgfqQ4IFpYWAtVixptyIRE5frMp/2A==",
       "dependencies": {
-        "@smithy/types": "^2.6.0",
+        "@smithy/types": "^2.7.0",
         "@smithy/util-uri-escape": "^2.0.0",
         "tslib": "^2.5.0"
       },
@@ -2306,11 +2601,11 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.14.tgz",
-      "integrity": "sha512-+cbtXWI9tNtQjlgQg3CA+pvL3zKTAxPnG3Pj6MP89CR3vi3QMmD0SOWoq84tqZDnJCxlsusbgIXk1ngMReXo+A==",
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.15.tgz",
+      "integrity": "sha512-jbBvoK3cc81Cj1c1TH1qMYxNQKHrYQ2DoTntN9FBbtUWcGhc+T4FP6kCKYwRLXyU4AajwGIZstvNAmIEgUUNTQ==",
       "dependencies": {
-        "@smithy/types": "^2.6.0",
+        "@smithy/types": "^2.7.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2318,22 +2613,22 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.7.tgz",
-      "integrity": "sha512-LLxgW12qGz8doYto15kZ4x1rHjtXl0BnCG6T6Wb8z2DI4PT9cJfOSvzbuLzy7+5I24PAepKgFeWHRd9GYy3Z9w==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.8.tgz",
+      "integrity": "sha512-jCw9+005im8tsfYvwwSc4TTvd29kXRFkH9peQBg5R/4DD03ieGm6v6Hpv9nIAh98GwgYg1KrztcINC1s4o7/hg==",
       "dependencies": {
-        "@smithy/types": "^2.6.0"
+        "@smithy/types": "^2.7.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.2.5.tgz",
-      "integrity": "sha512-LHA68Iu7SmNwfAVe8egmjDCy648/7iJR/fK1UnVw+iAOUJoEYhX2DLgVd5pWllqdDiRbQQzgaHLcRokM+UFR1w==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.2.7.tgz",
+      "integrity": "sha512-0Qt5CuiogIuvQIfK+be7oVHcPsayLgfLJGkPlbgdbl0lD28nUKu4p11L+UG3SAEsqc9UsazO+nErPXw7+IgDpQ==",
       "dependencies": {
-        "@smithy/types": "^2.6.0",
+        "@smithy/types": "^2.7.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2341,15 +2636,15 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.16.tgz",
-      "integrity": "sha512-ilLY85xS2kZZzTb83diQKYLIYALvart0KnBaKnIRnMBHAGEio5aHSlANQoxVn0VsonwmQ3CnWhnCT0sERD8uTg==",
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.18.tgz",
+      "integrity": "sha512-SJRAj9jT/l9ocm8D0GojMbnA1sp7I4JeStOQ4lEXI8A5eHE73vbjlzlqIFB7cLvIgau0oUl4cGVpF9IGCrvjlw==",
       "dependencies": {
-        "@smithy/eventstream-codec": "^2.0.14",
+        "@smithy/eventstream-codec": "^2.0.15",
         "@smithy/is-array-buffer": "^2.0.0",
-        "@smithy/types": "^2.6.0",
+        "@smithy/types": "^2.7.0",
         "@smithy/util-hex-encoding": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.7",
+        "@smithy/util-middleware": "^2.0.8",
         "@smithy/util-uri-escape": "^2.0.0",
         "@smithy/util-utf8": "^2.0.2",
         "tslib": "^2.5.0"
@@ -2359,13 +2654,13 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.16.tgz",
-      "integrity": "sha512-Lw67+yQSpLl4YkDLUzI2KgS8TXclXmbzSeOJUmRFS4ueT56B4pw3RZRF/SRzvgyxM/HxgkUan8oSHXCujPDafQ==",
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.18.tgz",
+      "integrity": "sha512-7FqdbaJiVaHJDD9IfDhmzhSDbpjyx+ZsfdYuOpDJF09rl8qlIAIlZNoSaflKrQ3cEXZN2YxGPaNWGhbYimyIRQ==",
       "dependencies": {
-        "@smithy/middleware-stack": "^2.0.8",
-        "@smithy/types": "^2.6.0",
-        "@smithy/util-stream": "^2.0.21",
+        "@smithy/middleware-stack": "^2.0.9",
+        "@smithy/types": "^2.7.0",
+        "@smithy/util-stream": "^2.0.23",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2373,9 +2668,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.6.0.tgz",
-      "integrity": "sha512-PgqxJq2IcdMF9iAasxcqZqqoOXBHufEfmbEUdN1pmJrJltT42b0Sc8UiYSWWzKkciIp9/mZDpzYi4qYG1qqg6g==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.7.0.tgz",
+      "integrity": "sha512-1OIFyhK+vOkMbu4aN2HZz/MomREkrAC/HqY5mlJMUJfGrPRwijJDTeiN8Rnj9zUaB8ogXAfIOtZrrgqZ4w7Wnw==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -2384,12 +2679,12 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.14.tgz",
-      "integrity": "sha512-kbu17Y1AFXi5lNlySdDj7ZzmvupyWKCX/0jNZ8ffquRyGdbDZb+eBh0QnWqsSmnZa/ctyWaTf7n4l/pXLExrnw==",
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.15.tgz",
+      "integrity": "sha512-sADUncUj9rNbOTrdDGm4EXlUs0eQ9dyEo+V74PJoULY4jSQxS+9gwEgsPYyiu8PUOv16JC/MpHonOgqP/IEDZA==",
       "dependencies": {
-        "@smithy/querystring-parser": "^2.0.14",
-        "@smithy/types": "^2.6.0",
+        "@smithy/querystring-parser": "^2.0.15",
+        "@smithy/types": "^2.7.0",
         "tslib": "^2.5.0"
       }
     },
@@ -2406,9 +2701,9 @@
       }
     },
     "node_modules/@smithy/util-body-length-browser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.0.tgz",
-      "integrity": "sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.1.tgz",
+      "integrity": "sha512-NXYp3ttgUlwkaug4bjBzJ5+yIbUbUx8VsSLuHZROQpoik+gRkIBeEG9MPVYfvPNpuXb/puqodeeUXcKFe7BLOQ==",
       "dependencies": {
         "tslib": "^2.5.0"
       }
@@ -2448,13 +2743,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.20.tgz",
-      "integrity": "sha512-QJtnbTIl0/BbEASkx1MUFf6EaoWqWW1/IM90N++8NNscePvPf77GheYfpoPis6CBQawUWq8QepTP2QUSAdrVkw==",
+      "version": "2.0.22",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.22.tgz",
+      "integrity": "sha512-qcF20IHHH96FlktvBRICDXDhLPtpVmtksHmqNGtotb9B0DYWXsC6jWXrkhrrwF7tH26nj+npVTqh9isiFV1gdA==",
       "dependencies": {
-        "@smithy/property-provider": "^2.0.15",
-        "@smithy/smithy-client": "^2.1.16",
-        "@smithy/types": "^2.6.0",
+        "@smithy/property-provider": "^2.0.16",
+        "@smithy/smithy-client": "^2.1.18",
+        "@smithy/types": "^2.7.0",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       },
@@ -2463,33 +2758,20 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "2.0.26",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.26.tgz",
-      "integrity": "sha512-lGFPOFCHv1ql019oegYqa54BZH7HREw6EBqjDLbAr0wquMX0BDi2sg8TJ6Eq+JGLijkZbJB73m4+aK8OFAapMg==",
+      "version": "2.0.29",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.29.tgz",
+      "integrity": "sha512-+uG/15VoUh6JV2fdY9CM++vnSuMQ1VKZ6BdnkUM7R++C/vLjnlg+ToiSR1FqKZbMmKBXmsr8c/TsDWMAYvxbxQ==",
       "dependencies": {
-        "@smithy/config-resolver": "^2.0.19",
-        "@smithy/credential-provider-imds": "^2.1.2",
-        "@smithy/node-config-provider": "^2.1.6",
-        "@smithy/property-provider": "^2.0.15",
-        "@smithy/smithy-client": "^2.1.16",
-        "@smithy/types": "^2.6.0",
+        "@smithy/config-resolver": "^2.0.21",
+        "@smithy/credential-provider-imds": "^2.1.4",
+        "@smithy/node-config-provider": "^2.1.8",
+        "@smithy/property-provider": "^2.0.16",
+        "@smithy/smithy-client": "^2.1.18",
+        "@smithy/types": "^2.7.0",
         "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@smithy/util-endpoints": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.0.5.tgz",
-      "integrity": "sha512-K7qNuCOD5K/90MjHvHm9kJldrfm40UxWYQxNEShMFxV/lCCCRIg8R4uu1PFAxRvPxNpIdcrh1uK6I1ISjDXZJw==",
-      "dependencies": {
-        "@smithy/node-config-provider": "^2.1.6",
-        "@smithy/types": "^2.6.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
       }
     },
     "node_modules/@smithy/util-hex-encoding": {
@@ -2504,11 +2786,11 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.7.tgz",
-      "integrity": "sha512-tRINOTlf1G9B0ECarFQAtTgMhpnrMPSa+5j4ZEwEawCLfTFTavk6757sxhE4RY5RMlD/I3x+DCS8ZUiR8ho9Pw==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.8.tgz",
+      "integrity": "sha512-qkvqQjM8fRGGA8P2ydWylMhenCDP8VlkPn8kiNuFEaFz9xnUKC2irfqsBSJrfrOB9Qt6pQsI58r3zvvumhFMkw==",
       "dependencies": {
-        "@smithy/types": "^2.6.0",
+        "@smithy/types": "^2.7.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2516,12 +2798,12 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.7.tgz",
-      "integrity": "sha512-fIe5yARaF0+xVT1XKcrdnHKTJ1Vc4+3e3tLDjCuIcE9b6fkBzzGFY7AFiX4M+vj6yM98DrwkuZeHf7/hmtVp0Q==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.8.tgz",
+      "integrity": "sha512-cQTPnVaVFMjjS6cb44WV2yXtHVyXDC5icKyIbejMarJEApYeJWpBU3LINTxHqp/tyLI+MZOUdosr2mZ3sdziNg==",
       "dependencies": {
-        "@smithy/service-error-classification": "^2.0.7",
-        "@smithy/types": "^2.6.0",
+        "@smithy/service-error-classification": "^2.0.8",
+        "@smithy/types": "^2.7.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2529,13 +2811,13 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "2.0.21",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.21.tgz",
-      "integrity": "sha512-0BUE16d7n1x7pi1YluXJdB33jOTyBChT0j/BlOkFa9uxfg6YqXieHxjHNuCdJRARa7AZEj32LLLEPJ1fSa4inA==",
+      "version": "2.0.23",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.23.tgz",
+      "integrity": "sha512-OJMWq99LAZJUzUwTk+00plyxX3ESktBaGPhqNIEVab+53gLULiWN9B/8bRABLg0K6R6Xg4t80uRdhk3B/LZqMQ==",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^2.2.7",
-        "@smithy/node-http-handler": "^2.1.10",
-        "@smithy/types": "^2.6.0",
+        "@smithy/fetch-http-handler": "^2.3.1",
+        "@smithy/node-http-handler": "^2.2.1",
+        "@smithy/types": "^2.7.0",
         "@smithy/util-base64": "^2.0.1",
         "@smithy/util-buffer-from": "^2.0.0",
         "@smithy/util-hex-encoding": "^2.0.0",
@@ -5838,6 +6120,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/w3c-xmlserializer": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.461.0",
+    "@aws-sdk/client-s3": "~3.437.0",
     "@inquirer/prompts": "^3.2.0",
     "@mux/mux-node": "8.0.0-canary.0",
     "@mux/mux-player-react": "2.2.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,10 +46,10 @@ export async function getVideoConfig(): Promise<VideoConfigComplete> {
     // Import the app's next.config.(m)js file so the env variable
     // __NEXT_VIDEO_OPTS set in with-next-video.ts can be used.
     try {
-      await import(path.resolve('next.config.js'));
+      await import(/* webpackIgnore: true */ path.resolve('next.config.js'));
     } catch {
       try {
-        await import(path.resolve('next.config.mjs'));
+        await import(/* webpackIgnore: true */ path.resolve('next.config.mjs'));
       } catch {
         console.error('Failed to load next.config.js or next.config.mjs');
       }

--- a/src/with-next-video.ts
+++ b/src/with-next-video.ts
@@ -56,14 +56,6 @@ export async function withNextVideo(nextConfig: any, videoConfig?: VideoConfig) 
         }, config.externals);
       }
 
-      config.infrastructureLogging = {
-        ...config.infrastructureLogging,
-        // Silence warning about dynamic import of next.config file.
-        // > [webpack.cache.PackFileCacheStrategy/webpack.FileSystemInfo] Parsing of /Users/wes/Sites/mux/next-video/dist/config.js for build dependencies failed at 'import(path.resolve("next.config.js"))'.
-        // > Build dependencies behind this expression are ignored and might cause incorrect cache invalidation.
-        level: 'error',
-      };
-
       config.experiments.buildHttp = {
         allowedUris: [
           /https?:\/\/.*\.(mp4|webm|mkv|ogg|ogv|wmv|avi|mov|flv|m4v|3gp)\??(?:&?[^=&]*=[^=&]*)*$/,


### PR DESCRIPTION
- [fix: Webpack dynamic import warning better](https://github.com/muxinc/next-video/commit/bf5a5300705112a339304ecf12fe3f74c04722f6)
- [fix: downgrade @aws-sdk/client-s3 to fix bundling](https://github.com/muxinc/next-video/commit/1ff9773b2f85c44393049172b7e816fb2a985d7f)

related issue https://github.com/aws/aws-sdk-js-v3/issues/5435

this happened only when using string video sources so it would use an API endpoint and when bundling or importing the AWS sdk it would throw this 

> TypeError: endpointFunctions_1.endpointFunctions[fn] is not a function

statically imported local or remote video sources worked fine.