### PR TITLE
fix: process types

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "./process": {
       "import": "./dist/process.js",
       "require": "./dist/cjs/process.js",
-      "default": "./dist/process.js",
-      "types": "./dist/process.d.ts"
+      "default": "./dist/process.js"
     },
     "./request-handler": "./dist/request-handler.js",
     "./video-types/*": "./video-types/*.d.ts",
@@ -36,9 +35,9 @@
   },
   "typesVersions": {
     "*": {
-      "*": [
-        "./dist/*"
-      ]
+      "process": ["./dist/process.d.ts"],
+      "request-handler": ["./dist/request-handler.d.ts"],
+      "*": ["./dist/*"]
     }
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "./process": {
       "import": "./dist/process.js",
       "require": "./dist/cjs/process.js",
-      "default": "./dist/process.js"
+      "default": "./dist/process.js",
+      "types": "./dist/process.d.ts"
     },
     "./request-handler": "./dist/request-handler.js",
     "./video-types/*": "./video-types/*.d.ts",


### PR DESCRIPTION
https://codesandbox.io/p/devbox/next-video-vercel-blob-h3n69k?file=%2Fnext.config.js%3A7%2C45

is complaining about the types not being found. trying a canary to see if this fixes it...