### PR TITLE
fix: set aspect on container, easier override

### DIFF
--- a/src/components/video.tsx
+++ b/src/components/video.tsx
@@ -58,12 +58,13 @@ const NextVideo = forwardRef<DefaultPlayerRefAttributes | null, VideoProps>((pro
         .next-video-container {
           position: relative;
           width: 100%;
+          aspect-ratio: 16 / 9;
         }
 
         [data-next-video] {
           position: relative;
           width: 100%;
-          aspect-ratio: 16 / 9;
+          height: 100%;
           display: inline-block;
           line-height: 0;
         }


### PR DESCRIPTION
related issue https://github.com/muxinc/next-video/issues/131

related PR https://github.com/muxinc/next-video/pull/79

if a width AND height is set on the container via CSS the internal player should expand to the container and not keep the default aspect-ratio of 16:9 that is set.