### PR TITLE
Choose your variables names for the s3 provider

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,6 @@ import path from 'node:path';
  * Video configurations
  */
 export type VideoConfigComplete = {
-
   /** The folder in your project where you will put all video source files. */
   folder: string;
 
@@ -20,13 +19,15 @@ export type VideoConfigComplete = {
     backblaze?: {
       endpoint: string;
       bucket?: string;
-    },
+    };
     'amazon-s3'?: {
       endpoint: string;
       bucket?: string;
-    },
-  }
-}
+      access_key?: string;
+      secret_key?: string;
+    };
+  };
+};
 
 export type VideoConfig = Partial<VideoConfigComplete>;
 
@@ -35,7 +36,7 @@ export const videoConfigDefault: VideoConfigComplete = {
   path: '/api/video',
   provider: 'mux',
   providerConfig: {},
-}
+};
 
 /**
  * The video config is set in `next.config.js` and passed to the `withNextVideo` function.

--- a/src/providers/amazon-s3/provider.ts
+++ b/src/providers/amazon-s3/provider.ts
@@ -16,7 +16,9 @@ import log from '../../utils/logger.js';
 export type AmazonS3Metadata = {
   bucket?: string;
   endpoint?: string;
-}
+  access_key?: string;
+  secret_key?: string;
+};
 
 // Why 11?
 //  - Reasonable id length visually in the src URL
@@ -42,14 +44,14 @@ async function initS3() {
     endpoint,
     region,
     credentials: {
-      accessKeyId: env.AWS_ACCESS_KEY_ID ?? '',
-      secretAccessKey: env.AWS_SECRET_ACCESS_KEY ?? '',
-    }
+      accessKeyId: amazonS3Config?.access_key ?? env.AWS_SECRET_ACCESS_KEY ?? '',
+      secretAccessKey: amazonS3Config?.secret_key ?? env.AWS_SECRET_ACCESS_KEY ?? '',
+    },
   });
 
   if (!bucketName) {
     try {
-      const bucket = await findBucket(s3, bucket => bucket.Name?.startsWith('next-videos-'));
+      const bucket = await findBucket(s3, (bucket) => bucket.Name?.startsWith('next-videos-'));
 
       if (bucket) {
         bucketName = bucket.Name!;
@@ -75,7 +77,7 @@ async function initS3() {
 
         // Since the security changes the default ObjectOwnership is BucketOwnerEnforced which doesn't allow ACLs. Change it here.
         // InvalidBucketAclWithObjectOwnership: Bucket cannot have ACLs set with ObjectOwnership's BucketOwnerEnforced setting
-        ObjectOwnership: 'ObjectWriter'
+        ObjectOwnership: 'ObjectWriter',
       });
       await putBucketAcl(s3, bucketName);
       await putBucketCors(s3, bucketName);
@@ -109,7 +111,7 @@ export async function uploadLocalFile(asset: Asset) {
   }
 
   await updateAsset(filePath, {
-    status: 'uploading'
+    status: 'uploading',
   });
 
   await initS3();
@@ -134,7 +136,7 @@ export async function uploadRequestedFile(asset: Asset) {
   }
 
   await updateAsset(filePath, {
-    status: 'uploading'
+    status: 'uploading',
   });
 
   await initS3();
@@ -180,7 +182,7 @@ async function putAsset(filePath: string, size: number, stream: ReadStream | Rea
       'amazon-s3': {
         endpoint,
         bucket: bucketName,
-      } as AmazonS3Metadata
+      } as AmazonS3Metadata,
     },
   });
 


### PR DESCRIPTION
## Why?
- There are some rare/weird cases when using CD/CI pipelines where the use of some variable names are forbidden, for that cases i think is good that we have the option to choose our own variable names for the secrets, if we want to.
 - #136 

## What's new?
Added extra config for the S3 provider 
![changes](https://github.com/muxinc/next-video/assets/52469780/774285d5-6125-4ca9-9a62-24796fd23be0)

