### PR TITLE
feat: custom local remote source folder & custom asset bucket key

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -29,7 +29,7 @@ export type ProviderConfig = {
 
   'vercel-blob'?: {
     /* An optional function to generate the bucket asset key. */
-    generateAssetKey?: (filePathOrURL: string) => string;
+    generateAssetKey?: (filePathOrURL: string, folder: string) => string;
   };
 
   backblaze?: {
@@ -38,7 +38,7 @@ export type ProviderConfig = {
     accessKeyId?: string;
     secretAccessKey?: string;
     /* An optional function to generate the bucket asset key. */
-    generateAssetKey?: (filePathOrURL: string) => string;
+    generateAssetKey?: (filePathOrURL: string, folder: string) => string;
   };
 
   'amazon-s3'?: {
@@ -47,7 +47,7 @@ export type ProviderConfig = {
     accessKeyId?: string;
     secretAccessKey?: string;
     /* An optional function to generate the bucket asset key. */
-    generateAssetKey?: (filePathOrURL: string) => string;
+    generateAssetKey?: (filePathOrURL: string, folder: string) => string;
   };
 };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,6 @@ import { pathToFileURL } from 'node:url';
  * Video configurations
  */
 export type VideoConfigComplete = {
-
   /** The folder in your project where you will put all video source files. */
   folder: string;
 
@@ -14,22 +13,43 @@ export type VideoConfigComplete = {
   path: string;
 
   /* The default provider that will deliver your video. */
-  provider: string;
+  provider: keyof ProviderConfig;
 
   /* Config by provider. */
-  providerConfig: {
-    backblaze?: {
-      endpoint: string;
-      bucket?: string;
-    },
-    'amazon-s3'?: {
-      endpoint: string;
-      bucket?: string;
-      accessKeyId?: string;
-      secretAccessKey?: string;
-    },
-  }
-}
+  providerConfig: ProviderConfig;
+
+  /* An optional function to generate the local asset path for remote sources. */
+  remoteSourceAssetPath?: (url: string) => string;
+};
+
+export type ProviderConfig = {
+  mux?: {
+    generateAssetKey: undefined;
+  };
+
+  'vercel-blob'?: {
+    /* An optional function to generate the bucket asset key. */
+    generateAssetKey?: (filePathOrURL: string) => string;
+  };
+
+  backblaze?: {
+    endpoint: string;
+    bucket?: string;
+    accessKeyId?: string;
+    secretAccessKey?: string;
+    /* An optional function to generate the bucket asset key. */
+    generateAssetKey?: (filePathOrURL: string) => string;
+  };
+
+  'amazon-s3'?: {
+    endpoint: string;
+    bucket?: string;
+    accessKeyId?: string;
+    secretAccessKey?: string;
+    /* An optional function to generate the bucket asset key. */
+    generateAssetKey?: (filePathOrURL: string) => string;
+  };
+};
 
 export type VideoConfig = Partial<VideoConfigComplete>;
 
@@ -38,33 +58,30 @@ export const videoConfigDefault: VideoConfigComplete = {
   path: '/api/video',
   provider: 'mux',
   providerConfig: {},
-}
+};
 
 /**
  * The video config is set in `next.config.js` and passed to the `withNextVideo` function.
  * The video config is then stored as an environment variable __NEXT_VIDEO_OPTS.
  */
 export async function getVideoConfig(): Promise<VideoConfigComplete> {
-  if (!env['__NEXT_VIDEO_OPTS']) {
-    // Import the app's next.config.(m)js file so the env variable
-    // __NEXT_VIDEO_OPTS set in with-next-video.ts can be used.
-    try {
-      await importConfig('next.config.js');
-    } catch (err) {
-      console.error(err);
+  let nextConfig;
 
-      try {
-        await importConfig('next.config.mjs');
-      } catch {
-        console.error('Failed to load next.config.js or next.config.mjs');
-      }
+  try {
+    nextConfig = await importConfig('next.config.js');
+  } catch (err) {
+    try {
+      nextConfig = await importConfig('next.config.mjs');
+    } catch {
+      console.error('Failed to load next.config.js or next.config.mjs');
     }
   }
-  return JSON.parse(env['__NEXT_VIDEO_OPTS'] ?? '{}');
+
+  return nextConfig?.serverRuntimeConfig?.nextVideo;
 }
 
 async function importConfig(file: string) {
   const absFilePath = path.resolve(cwd(), file);
   const fileUrl = pathToFileURL(absFilePath).href;
-  return import(/* webpackIgnore: true */ fileUrl);
+  return (await import(/* webpackIgnore: true */ fileUrl))?.default;
 }

--- a/src/providers/amazon-s3/provider.ts
+++ b/src/providers/amazon-s3/provider.ts
@@ -1,7 +1,6 @@
 import { ReadStream, createReadStream } from 'node:fs';
 import { Readable } from 'node:stream';
 import fs from 'node:fs/promises';
-import path from 'node:path';
 import { env } from 'node:process';
 import { fetch as uFetch } from 'undici';
 import chalk from 'chalk';
@@ -160,7 +159,7 @@ async function putAsset(filePath: string, size: number, stream: ReadStream | Rea
     await putObject(s3, {
       ACL: 'public-read',
       Bucket: bucketName,
-      Key: path.basename(filePath),
+      Key: filePath,
       Body: stream,
       ContentLength: size,
     });

--- a/src/providers/amazon-s3/provider.ts
+++ b/src/providers/amazon-s3/provider.ts
@@ -10,13 +10,14 @@ import { S3Client } from '@aws-sdk/client-s3';
 import { updateAsset, Asset } from '../../assets.js';
 import { getVideoConfig } from '../../config.js';
 import { findBucket, createBucket, putBucketCors, putObject, putBucketAcl } from '../../utils/s3.js';
+import { createAssetKey } from '../../utils/provider.js';
+import { isRemote } from '../../utils/utils.js';
 import log from '../../utils/logger.js';
 
 export type AmazonS3Metadata = {
   bucket?: string;
   endpoint?: string;
-  accessKeyId?: string;
-  secretAccessKey?: string;
+  key?: string;
 }
 
 // Why 11?
@@ -97,7 +98,7 @@ export async function uploadLocalFile(asset: Asset) {
   }
 
   // Handle imported remote videos.
-  if (filePath && /^https?:\/\//.test(filePath)) {
+  if (isRemote(filePath)) {
     return uploadRequestedFile(asset);
   }
 
@@ -155,11 +156,14 @@ export async function uploadRequestedFile(asset: Asset) {
 async function putAsset(filePath: string, size: number, stream: ReadStream | Readable) {
   log.info(log.label('Uploading file:'), `${filePath} (${size} bytes)`);
 
+  let key;
   try {
+    key = await createAssetKey(filePath, 'amazon-s3');
+
     await putObject(s3, {
       ACL: 'public-read',
       Bucket: bucketName,
-      Key: filePath,
+      Key: key,
       Body: stream,
       ContentLength: size,
     });
@@ -181,6 +185,7 @@ async function putAsset(filePath: string, size: number, stream: ReadStream | Rea
       'amazon-s3': {
         endpoint,
         bucket: bucketName,
+        key,
       } as AmazonS3Metadata
     },
   });

--- a/src/providers/amazon-s3/transformer.ts
+++ b/src/providers/amazon-s3/transformer.ts
@@ -6,9 +6,7 @@ export function transform(asset: Asset) {
 
   const src = new URL(providerMetadata.endpoint);
   src.hostname = `${providerMetadata.bucket}.${src.hostname}`;
-
-  const basename = asset.originalFilePath.split('/').pop();
-  if (basename) src.pathname = basename
+  src.pathname = asset.originalFilePath;
 
   const source: AssetSource = { src: `${src}` };
 

--- a/src/providers/amazon-s3/transformer.ts
+++ b/src/providers/amazon-s3/transformer.ts
@@ -6,7 +6,7 @@ export function transform(asset: Asset) {
 
   const src = new URL(providerMetadata.endpoint);
   src.hostname = `${providerMetadata.bucket}.${src.hostname}`;
-  src.pathname = asset.originalFilePath;
+  src.pathname = providerMetadata.key;
 
   const source: AssetSource = { src: `${src}` };
 

--- a/src/providers/backblaze/provider.ts
+++ b/src/providers/backblaze/provider.ts
@@ -1,7 +1,6 @@
 import { ReadStream, createReadStream } from 'node:fs';
 import { Readable } from 'node:stream';
 import fs from 'node:fs/promises';
-import path from 'node:path';
 import { env } from 'node:process';
 import { fetch as uFetch } from 'undici';
 import chalk from 'chalk';
@@ -148,7 +147,7 @@ async function putAsset(filePath: string, size: number, stream: ReadStream | Rea
   try {
     await putObject(s3, {
       Bucket: bucketName,
-      Key: path.basename(filePath),
+      Key: filePath,
       Body: stream,
       ContentLength: size,
     });

--- a/src/providers/backblaze/provider.ts
+++ b/src/providers/backblaze/provider.ts
@@ -10,11 +10,14 @@ import { S3Client } from '@aws-sdk/client-s3';
 import { updateAsset, Asset } from '../../assets.js';
 import { getVideoConfig } from '../../config.js';
 import { findBucket, createBucket, putBucketCors, putObject } from '../../utils/s3.js';
+import { createAssetKey } from '../../utils/provider.js';
+import { isRemote } from '../../utils/utils.js';
 import log from '../../utils/logger.js';
 
 export type BackblazeMetadata = {
   bucket?: string;
   endpoint?: string;
+  key?: string;
 }
 
 // Why 11?
@@ -41,8 +44,8 @@ async function initS3() {
     endpoint,
     region,
     credentials: {
-      accessKeyId: env.BACKBLAZE_ACCESS_KEY_ID ?? '',
-      secretAccessKey: env.BACKBLAZE_SECRET_ACCESS_KEY ?? '',
+      accessKeyId: backblazeConfig?.accessKeyId ?? env.BACKBLAZE_ACCESS_KEY_ID ?? '',
+      secretAccessKey: backblazeConfig?.secretAccessKey ?? env.BACKBLAZE_SECRET_ACCESS_KEY ?? '',
     }
   });
 
@@ -86,7 +89,7 @@ export async function uploadLocalFile(asset: Asset) {
   }
 
   // Handle imported remote videos.
-  if (filePath && /^https?:\/\//.test(filePath)) {
+  if (isRemote(filePath)) {
     return uploadRequestedFile(asset);
   }
 
@@ -144,10 +147,13 @@ export async function uploadRequestedFile(asset: Asset) {
 async function putAsset(filePath: string, size: number, stream: ReadStream | Readable) {
   log.info(log.label('Uploading file:'), `${filePath} (${size} bytes)`);
 
+  let key;
   try {
+    key = await createAssetKey(filePath, 'backblaze');
+
     await putObject(s3, {
       Bucket: bucketName,
-      Key: filePath,
+      Key: key,
       Body: stream,
       ContentLength: size,
     });
@@ -169,6 +175,7 @@ async function putAsset(filePath: string, size: number, stream: ReadStream | Rea
       backblaze: {
         endpoint,
         bucket: bucketName,
+        key,
       } as BackblazeMetadata
     },
   });

--- a/src/providers/backblaze/transformer.ts
+++ b/src/providers/backblaze/transformer.ts
@@ -6,9 +6,7 @@ export function transform(asset: Asset) {
 
   const src = new URL(providerMetadata.endpoint);
   src.hostname = `${providerMetadata.bucket}.${src.hostname}`;
-
-  const basename = asset.originalFilePath.split('/').pop();
-  if (basename) src.pathname = basename
+  src.pathname = asset.originalFilePath;
 
   const source: AssetSource = { src: `${src}` };
 

--- a/src/providers/backblaze/transformer.ts
+++ b/src/providers/backblaze/transformer.ts
@@ -6,7 +6,7 @@ export function transform(asset: Asset) {
 
   const src = new URL(providerMetadata.endpoint);
   src.hostname = `${providerMetadata.bucket}.${src.hostname}`;
-  src.pathname = asset.originalFilePath;
+  src.pathname = providerMetadata.key;
 
   const source: AssetSource = { src: `${src}` };
 

--- a/src/request-handler.ts
+++ b/src/request-handler.ts
@@ -2,6 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { callHandler } from './process.js';
 import { createAsset, getAsset } from './assets.js';
 import { getVideoConfig } from './config.js';
+import { isRemote } from './utils/utils.js';
 
 // App Router
 export async function GET(request: Request) {
@@ -26,10 +27,7 @@ async function handleRequest(url?: string | null) {
     };
   }
 
-  const remoteRegex = /^https?:\/\//;
-  const isRemote = remoteRegex.test(url);
-
-  if (!isRemote) {
+  if (!isRemote(url)) {
     // todo: handle local files via string src
     return {
       status: 400,

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -1,0 +1,33 @@
+import * as path from 'node:path';
+
+import { getVideoConfig } from '../config.js';
+import { isRemote } from './utils.js';
+
+import type { ProviderConfig } from '../config.js';
+
+export async function createAssetKey(filePathOrURL: string, provider: keyof ProviderConfig) {
+  const { folder, providerConfig } = await getVideoConfig();
+  const config = providerConfig[provider];
+  const { generateAssetKey = defaultGenerateAssetKey } = config ?? {};
+
+  if (!isRemote(filePathOrURL)) {
+    return generateAssetKey(filePathOrURL);
+  }
+
+  // Add the configured folder and make remote url a safe file path.
+  return path.posix.join(folder, generateAssetKey(filePathOrURL));
+}
+
+function defaultGenerateAssetKey(filePathOrURL: string) {
+  // By default local imports keep the same local folder structure.
+  if (!isRemote(filePathOrURL)) return filePathOrURL;
+
+  const url = new URL(filePathOrURL);
+
+  // By default remote imports are stored in the root folder with just the file name.
+
+  // This could easily lead to collisions if the same file name is used in different
+  // remote sources. There are many ways to generate unique asset keys from
+  // remote sources, so we leave this up to the user to configure.
+  return path.basename(decodeURIComponent(url.pathname));
+}

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -9,25 +9,18 @@ export async function createAssetKey(filePathOrURL: string, provider: keyof Prov
   const { folder, providerConfig } = await getVideoConfig();
   const config = providerConfig[provider];
   const { generateAssetKey = defaultGenerateAssetKey } = config ?? {};
-
-  if (!isRemote(filePathOrURL)) {
-    return generateAssetKey(filePathOrURL);
-  }
-
-  // Add the configured folder and make remote url a safe file path.
-  return path.posix.join(folder, generateAssetKey(filePathOrURL));
+  return generateAssetKey(filePathOrURL, folder);
 }
 
-function defaultGenerateAssetKey(filePathOrURL: string) {
+function defaultGenerateAssetKey(filePathOrURL: string, folder: string) {
   // By default local imports keep the same local folder structure.
   if (!isRemote(filePathOrURL)) return filePathOrURL;
 
   const url = new URL(filePathOrURL);
 
-  // By default remote imports are stored in the root folder with just the file name.
-
+  // Remote imports are stored in the configured videos folder with just the file name.
   // This could easily lead to collisions if the same file name is used in different
-  // remote sources. There are many ways to generate unique asset keys from
-  // remote sources, so we leave this up to the user to configure.
-  return path.basename(decodeURIComponent(url.pathname));
+  // remote sources. There are many ways to generate unique asset keys from remote sources,
+  // so we leave this up to the user to configure if needed.
+  return path.posix.join(folder, path.basename(decodeURIComponent(url.pathname)));
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -6,6 +6,16 @@ export function camelCase(name: string) {
   return name.replace(/[-_]([a-z])/g, ($0, $1) => $1.toUpperCase());
 }
 
+export function isRemote(filePath: string) {
+  return /^https?:\/\//.test(filePath);
+}
+
+export function toSafePath(str: string) {
+  return str
+    .replace(/^[^a-zA-Z0-9]+|[^a-zA-Z0-9]+$/g, '')
+    .replace(/[^a-zA-Z0-9._-]+/g, '_');
+}
+
 /**
 * Performs a deep merge of objects and returns a new object.
 * Does not modify objects (immutable) and merges arrays via concatenation.

--- a/src/webpack-loader.ts
+++ b/src/webpack-loader.ts
@@ -6,7 +6,8 @@ import { createAsset, getAssetConfigPath } from './assets.js';
 export const raw = true;
 
 export default async function loader(this: any, source: Buffer) {
-  const assetPath = path.resolve(await getAssetConfigPath(this.resourcePath));
+  const importPath = `${this.resourcePath}${this.resourceQuery ?? ''}`;
+  const assetPath = path.resolve(await getAssetConfigPath(importPath));
 
   this.addDependency(assetPath);
 
@@ -14,7 +15,7 @@ export default async function loader(this: any, source: Buffer) {
   try {
     asset = await readFile(assetPath, 'utf-8');
   } catch {
-    asset = JSON.stringify(await createAsset(this.resourcePath, {
+    asset = JSON.stringify(await createAsset(importPath, {
       status: 'sourced'
     }));
   }

--- a/src/with-next-video.ts
+++ b/src/with-next-video.ts
@@ -39,6 +39,10 @@ export async function withNextVideo(nextConfig: any, videoConfig?: VideoConfig) 
   }
 
   return Object.assign({}, nextConfig, {
+    serverRuntimeConfig: {
+      ...nextConfig.serverRuntimeConfig,
+      nextVideo: videoConfigComplete,
+    },
     webpack(config: any, options: any) {
       if (!options.defaultLoaders) {
         throw new Error(

--- a/tests/components/video.test.tsx
+++ b/tests/components/video.test.tsx
@@ -1,31 +1,35 @@
 import assert from 'node:assert';
 import { test } from 'node:test';
 import { setTimeout } from 'node:timers/promises';
-import { create, act } from 'react-test-renderer';
+import { create } from 'react-test-renderer';
 import React from 'react';
 import asset from '../factories/BBB-720p-1min.mp4.json' assert { type: "json" };
 import Video from '../../src/components/video.js';
 
-test('renders a video container', () => {
+test('renders a video container', async () => {
   const wrapper = create(<Video />);
+  await setTimeout(50);
   assert.equal(wrapper.toJSON().type, 'div');
   assert.equal(wrapper.toJSON().props.className, 'next-video-container');
 });
 
-test('prepends a class to the video container', () => {
+test('prepends a class to the video container', async () => {
   const wrapper = create(<Video className="foo" />);
+  await setTimeout(50);
   assert.equal(wrapper.toJSON().props.className, 'foo next-video-container');
 });
 
 test('renders mux-player without source', async () => {
   await import('@mux/mux-player-react');
   const wrapper = create(<Video />);
+  await setTimeout(50);
   assert.equal(wrapper.toJSON().children[1].type, 'mux-player');
 });
 
 test('renders mux-player with imported source', async () => {
   await import('@mux/mux-player-react');
   const wrapper = create(<Video src={asset} />);
+  await setTimeout(50);
   assert.equal(wrapper.toJSON().children[1].type, 'mux-player');
   assert.equal(
     wrapper.root.findByType('mux-player').parent.parent.props.playbackId,


### PR DESCRIPTION
fix #149
also fixes a few bugs with reading files in nested folders and creating a file in a nested folder.

this change adds 2 new configurations

```js
  /* An optional function to generate the local asset path for remote sources. */
  remoteSourceAssetPath?: (url: string) => string;
```

this allows you to change the local folder structure in the configured videos folder for remote sources.
for example you might want to make this 

`/videos/remote/www.dropbox.com_s_dqzkxva260lo7mm_Mad_Max_Cropped.mp4.json` 

instead of the default

`/videos/www.dropbox.com_s_dqzkxva260lo7mm_Mad_Max_Cropped.mp4.json`

or strip the domain and dirname altogether

`/videos/remote/Mad_Max_Cropped.mp4.json`

---

for all the bucket providers (vercel-blob, backblaze, amazon-s3) it adds 

```js
    /* An optional function to generate the bucket asset key. */
    generateAssetKey?: (filePathOrURL: string) => string;
```

this allows you to change where you store your asset in the bucket.