### PR TITLE
Improved types for `withNextVideo` provider config 

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ const nextConfig = {};
 module.exports = withNextVideo(nextConfig, {
   provider: 'backblaze',
   providerConfig: {
-    backblaze: { endpoint: 'https://s3.us-west-000.backblazeb2.com' }
+    endpoint: 'https://s3.us-west-000.backblazeb2.com',
   }
 });
 ```

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,43 +12,60 @@ export type VideoConfigComplete = {
   /** The route of the video API request for string video source URLs. */
   path: string;
 
-  /* The default provider that will deliver your video. */
-  provider: keyof ProviderConfig;
-
-  /* Config by provider. */
-  providerConfig: ProviderConfig;
-
   /* An optional function to generate the local asset path for remote sources. */
   remoteSourceAssetPath?: (url: string) => string;
+} & (
+  | { 
+    /* The default provider that will deliver your video. */
+    provider: 'mux'; 
+    /* Config by provider. */
+    providerConfig: MuxProviderConfig
+   }
+  | { 
+    /* The default provider that will deliver your video. */
+    provider: 'vercel-blob'; 
+    /* Config by provider. */
+    providerConfig: VercelBlobProviderConfig
+   }
+  | { 
+    /* The default provider that will deliver your video. */
+    provider: 'backblaze'; 
+    /* Config by provider. */
+    providerConfig: BackblazeProviderConfig
+   }
+  | { 
+    /* The default provider that will deliver your video. */
+    provider: 'amazon-s3'; 
+    /* Config by provider. */
+    providerConfig: AmazonS3ProviderConfig
+   }
+);
+
+type MuxProviderConfig = {
+  generateAssetKey: undefined;
 };
 
-export type ProviderConfig = {
-  mux?: {
-    generateAssetKey: undefined;
-  };
+type VercelBlobProviderConfig = {
+  /* An optional function to generate the bucket asset key. */
+  generateAssetKey?: (filePathOrURL: string, folder: string) => string;
+};
 
-  'vercel-blob'?: {
-    /* An optional function to generate the bucket asset key. */
-    generateAssetKey?: (filePathOrURL: string, folder: string) => string;
-  };
+type BackblazeProviderConfig = {
+  endpoint: string;
+  bucket?: string;
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  /* An optional function to generate the bucket asset key. */
+  generateAssetKey?: (filePathOrURL: string, folder: string) => string;
+};
 
-  backblaze?: {
-    endpoint: string;
-    bucket?: string;
-    accessKeyId?: string;
-    secretAccessKey?: string;
-    /* An optional function to generate the bucket asset key. */
-    generateAssetKey?: (filePathOrURL: string, folder: string) => string;
-  };
-
-  'amazon-s3'?: {
-    endpoint: string;
-    bucket?: string;
-    accessKeyId?: string;
-    secretAccessKey?: string;
-    /* An optional function to generate the bucket asset key. */
-    generateAssetKey?: (filePathOrURL: string, folder: string) => string;
-  };
+type AmazonS3ProviderConfig = {
+  endpoint: string;
+  bucket?: string;
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  /* An optional function to generate the bucket asset key. */
+  generateAssetKey?: (filePathOrURL: string, folder: string) => string;
 };
 
 export type VideoConfig = Partial<VideoConfigComplete>;

--- a/src/config.ts
+++ b/src/config.ts
@@ -74,14 +74,16 @@ export const videoConfigDefault: VideoConfigComplete = {
   folder: 'videos',
   path: '/api/video',
   provider: 'mux',
-  providerConfig: {},
+  providerConfig: {
+    generateAssetKey: undefined,
+  },
 };
 
 /**
  * The video config is set in `next.config.js` and passed to the `withNextVideo` function.
  * The video config is then stored as an environment variable __NEXT_VIDEO_OPTS.
  */
-export async function getVideoConfig(): Promise<VideoConfigComplete> {
+export async function getVideoConfig<T extends VideoConfig['provider']>(): Promise<Extract<VideoConfigComplete, { provider: T }>> {
   let nextConfig;
 
   try {

--- a/src/providers/amazon-s3/provider.ts
+++ b/src/providers/amazon-s3/provider.ts
@@ -32,8 +32,7 @@ let bucketName: string;
 let endpoint: string;
 
 async function initS3() {
-  const { providerConfig } = await getVideoConfig();
-  const amazonS3Config = providerConfig['amazon-s3'];
+  const { providerConfig: amazonS3Config } = await getVideoConfig<'amazon-s3'>();
   bucketName = amazonS3Config?.bucket ?? '';
   endpoint = amazonS3Config?.endpoint ?? '';
 

--- a/src/providers/backblaze/provider.ts
+++ b/src/providers/backblaze/provider.ts
@@ -32,8 +32,7 @@ let bucketName: string;
 let endpoint: string;
 
 async function initS3() {
-  const { providerConfig } = await getVideoConfig();
-  const backblazeConfig = providerConfig.backblaze;
+  const { providerConfig: backblazeConfig } = await getVideoConfig<'backblaze'>();
   bucketName = backblazeConfig?.bucket ?? '';
   endpoint = backblazeConfig?.endpoint ?? '';
 

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -1,13 +1,12 @@
 import * as path from 'node:path';
 
-import { getVideoConfig } from '../config.js';
+import { VideoConfigComplete, getVideoConfig } from '../config.js';
 import { isRemote } from './utils.js';
 
-import type { ProviderConfig } from '../config.js';
+type ProviderConfig = VideoConfigComplete['provider']
 
 export async function createAssetKey(filePathOrURL: string, provider: keyof ProviderConfig) {
-  const { folder, providerConfig } = await getVideoConfig();
-  const config = providerConfig[provider];
+  const { folder, providerConfig: config } = await getVideoConfig();
   const { generateAssetKey = defaultGenerateAssetKey } = config ?? {};
   return generateAssetKey(filePathOrURL, folder);
 }


### PR DESCRIPTION
The library accepts objects like the following as provider configs:

```
module.exports = withNextVideo(nextConfig, {
  provider: 'backblaze',
  providerConfig: {
    backblaze: { endpoint: 'https://s3.us-west-000.backblazeb2.com' }
  }
});
```

This is not the best approach because it can have inconsistencies, e.g I could set `mux` as a provider but use a `backblaze` provider config.

This PR apart from fixing this issue (now you can't use a providerConfig that doesn't correspond to the provider) it also simplifies a bit the config code:

```
module.exports = withNextVideo(nextConfig, {
  provider: 'backblaze',
  providerConfig: {
    backblaze: { endpoint: 'https://s3.us-west-000.backblazeb2.com' }
  }
});
```

->

```
module.exports = withNextVideo(nextConfig, {
  provider: 'backblaze',
  providerConfig: {
    endpoint: 'https://s3.us-west-000.backblazeb2.com' 
  }
});
```