### PR TITLE
fix: upgrade aws-sdk, Mux elements

### DIFF
--- a/examples/default-provider/next.config.mjs
+++ b/examples/default-provider/next.config.mjs
@@ -3,3 +3,13 @@ import { withNextVideo } from 'next-video/process';
 const nextConfig = {};
 
 export default withNextVideo(nextConfig);
+
+// Amazon S3 example
+// export default withNextVideo(nextConfig, {
+//   provider: 'amazon-s3',
+//   providerConfig: {
+//     'amazon-s3': {
+//       endpoint: 'https://s3.us-east-1.amazonaws.com',
+//     }
+//   },
+// });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,37 +9,37 @@
       "version": "0.17.1",
       "license": "MIT",
       "dependencies": {
-        "@aws-sdk/client-s3": "~3.540.0",
-        "@inquirer/prompts": "^3.2.0",
+        "@aws-sdk/client-s3": "^3.540.0",
+        "@inquirer/prompts": "^4.3.1",
         "@mux/mux-node": "8.2.3",
         "@mux/mux-player-react": "2.4.1",
         "@mux/mux-video-react": "^0.8.5",
         "@next/env": "^14.1.4",
         "@paralleldrive/cuid2": "^2.2.2",
         "@vercel/blob": "^0.22.1",
-        "chalk": "^4.1.2",
+        "chalk": "^5.3.0",
         "chokidar": "^3.6.0",
         "magicast": "^0.3.3",
         "symlink-dir": "^5.2.1",
-        "undici": "^5.25.4",
+        "undici": "^6.11.1",
         "yargs": "^17.7.2"
       },
       "bin": {
         "next-video": "dist/cli.js"
       },
       "devDependencies": {
-        "@types/dotenv-flow": "^3.3.1",
-        "@types/node": "^20.8.4",
-        "@types/react": "^18.2.27",
-        "@types/yargs": "^17.0.28",
+        "@types/dotenv-flow": "^3.3.3",
+        "@types/node": "^20.12.3",
+        "@types/react": "18.2.42",
+        "@types/yargs": "^17.0.32",
         "c8": "^9.1.0",
         "esbuild": "^0.20.2",
         "glob": "^10.3.12",
         "next": "^14.1.4",
         "react": "^18.2.0",
         "react-test-renderer": "^18.2.0",
-        "tsx": "^3.13.0",
-        "typescript": "^5.2.2"
+        "tsx": "3.13.0",
+        "typescript": "^5.4.3"
       },
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18",
@@ -901,70 +901,6 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
-      "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
-      "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
-      "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
-      "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
@@ -981,352 +917,92 @@
         "node": ">=12"
       }
     },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
-      "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
-      "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
-      "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
-      "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
-      "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
-      "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
-      "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
-      "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
-      "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
-      "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
-      "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
-      "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
-      "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
-      "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
-      "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
-      "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
-      "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
-      "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@fastify/busboy": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
-      "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-1.4.0.tgz",
-      "integrity": "sha512-7YcekwCvMTjrgjUursrH6AGZUSPw7gKPMvp0VhM3iq9mL46a7AeCfOTQTW0UPeiIfWmZK8wHyAD6wIhfDyLHpw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-2.2.1.tgz",
+      "integrity": "sha512-eYdhZWZMOaliMBPOL/AO3uId58lp+zMyrJdoZ2xw9hfUY4IYJlIMvgW80RJdvCY3q9fGMUyZI5GwguH2tO51ew==",
       "dependencies": {
-        "@inquirer/core": "^5.1.0",
-        "@inquirer/type": "^1.1.5",
+        "@inquirer/core": "^7.1.1",
+        "@inquirer/type": "^1.2.1",
         "ansi-escapes": "^4.3.2",
         "chalk": "^4.1.2",
         "figures": "^3.2.0"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/checkbox/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-2.0.14.tgz",
-      "integrity": "sha512-Elzo5VX5lO1q9xy8CChDtDQNVLaucufdZBAM12qdfX1L3NQ+TypnZytGmWDXHBTpBTwuhEuwxNvUw7B0HCURkw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-3.1.1.tgz",
+      "integrity": "sha512-epf2RVHJJxX5qF85U41PBq9qq2KTJW9sKNLx6+bb2/i2rjXgeoHVGUm8kJxZHavrESgXgBLKCABcfOJYIso8cQ==",
       "dependencies": {
-        "@inquirer/core": "^5.1.0",
-        "@inquirer/type": "^1.1.5",
-        "chalk": "^4.1.2"
+        "@inquirer/core": "^7.1.1",
+        "@inquirer/type": "^1.2.1"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=18"
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-5.1.0.tgz",
-      "integrity": "sha512-EVnific72BhMOMo8mElvrYhGFWJZ73X6j0I+fITIPTsdAz6Z9A3w3csKy+XaH87/5QAEIQHR7RSCVXvQpIqNdQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-7.1.1.tgz",
+      "integrity": "sha512-rD1UI3eARN9qJBcLRXPOaZu++Bg+xsk0Tuz1EUOXEW+UbYif1sGjr0Tw7lKejHzKD9IbXE1CEtZ+xR/DrNlQGQ==",
       "dependencies": {
-        "@inquirer/type": "^1.1.5",
-        "@types/mute-stream": "^0.0.2",
-        "@types/node": "^20.8.2",
+        "@inquirer/type": "^1.2.1",
+        "@types/mute-stream": "^0.0.4",
+        "@types/node": "^20.11.30",
         "@types/wrap-ansi": "^3.0.0",
         "ansi-escapes": "^4.3.2",
         "chalk": "^4.1.2",
-        "cli-spinners": "^2.9.1",
+        "cli-spinners": "^2.9.2",
         "cli-width": "^4.1.0",
         "figures": "^3.2.0",
         "mute-stream": "^1.0.0",
-        "run-async": "^3.0.0",
         "signal-exit": "^4.1.0",
         "strip-ansi": "^6.0.1",
         "wrap-ansi": "^6.2.0"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@inquirer/core/node_modules/wrap-ansi": {
@@ -1343,113 +1019,154 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-1.2.12.tgz",
-      "integrity": "sha512-Y7zXQqcglPbbPkx0DPwx6HQFstJR5uex4hoQprjpdxSj8+Bf04+Og6mK/FNxoQbPvoNecegtmMGxDC+hVcMJZA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-2.1.1.tgz",
+      "integrity": "sha512-SGVAmSKY2tt62+5KUySYFeMwJEXX866Ws5MyjwbrbB+WqC8iZAtPcK0pz8KVsO0ak/DB3/vCZw0k2nl7TifV5g==",
       "dependencies": {
-        "@inquirer/core": "^5.1.0",
-        "@inquirer/type": "^1.1.5",
-        "chalk": "^4.1.2",
+        "@inquirer/core": "^7.1.1",
+        "@inquirer/type": "^1.2.1",
         "external-editor": "^3.1.0"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=18"
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-1.1.13.tgz",
-      "integrity": "sha512-/+7CGCa7iyJIpli0NtukEAjSI7+wGgjYzsByLVSSAk3U696ZlCCP6iPtsWx6d1qfmaMmCzejcjylOj6OAeu4bA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-2.1.1.tgz",
+      "integrity": "sha512-FTHf56CgE24CtweB+3sF4mOFa6Q7H8NfTO+SvYio3CgQwhIWylSNueEeJ7sYBnWaXHNUfiX883akgvSbWqSBoQ==",
       "dependencies": {
-        "@inquirer/core": "^5.1.0",
-        "@inquirer/type": "^1.1.5",
-        "chalk": "^4.1.2",
-        "figures": "^3.2.0"
+        "@inquirer/core": "^7.1.1",
+        "@inquirer/type": "^1.2.1",
+        "chalk": "^4.1.2"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/expand/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-1.2.13.tgz",
-      "integrity": "sha512-gALuvSpZRYfqygPjlYWodMZ4TXwALvw7Pk4tRFhE1oMN79rLVlg88Z/X6JCUh+uV2qLaxxgbeP+cgPWTvuWsCg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-2.1.1.tgz",
+      "integrity": "sha512-Ag5PDh3/V3B68WGD/5LKXDqbdWKlF7zyfPAlstzu0NoZcZGBbZFjfgXlZIcb6Gs+AfdSi7wNf7soVAaMGH7moQ==",
       "dependencies": {
-        "@inquirer/core": "^5.1.0",
-        "@inquirer/type": "^1.1.5",
-        "chalk": "^4.1.2"
+        "@inquirer/core": "^7.1.1",
+        "@inquirer/type": "^1.2.1"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=18"
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-1.1.13.tgz",
-      "integrity": "sha512-6STGbL4Vm6ohE2yDBOSENCpCeywnvPux5psZVpvblGDop1oPiZkdsVI+NhsA0c4BE6YT0fNVK8Oqxf5Dgt5k7g==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-2.1.1.tgz",
+      "integrity": "sha512-R5R6NVXDKXEjAOGBqgRGrchFlfdZIx/qiDvH63m1u1NQVOQFUMfHth9VzVwuTZ2LHzbb9UrYpBumh2YytFE9iQ==",
       "dependencies": {
-        "@inquirer/input": "^1.2.13",
-        "@inquirer/type": "^1.1.5",
-        "ansi-escapes": "^4.3.2",
-        "chalk": "^4.1.2"
+        "@inquirer/core": "^7.1.1",
+        "@inquirer/type": "^1.2.1",
+        "ansi-escapes": "^4.3.2"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=18"
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-3.2.0.tgz",
-      "integrity": "sha512-sfT7eDoveChXr8iIfwUYkoVBjUcKqXluhjM0EVhRhN59ZuJCc5DAdnuKwaFXomwESDoN0f+2zHy+MpxUg+EZuQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-4.3.1.tgz",
+      "integrity": "sha512-FI8jhVm3GRJ/z40qf7YZnSP0TfPKDPdIYZT9W6hmiYuaSmAXL66YMXqonKyysE5DwtKQBhIqt0oSoTKp7FCvQQ==",
       "dependencies": {
-        "@inquirer/checkbox": "^1.4.0",
-        "@inquirer/confirm": "^2.0.14",
-        "@inquirer/core": "^5.1.0",
-        "@inquirer/editor": "^1.2.12",
-        "@inquirer/expand": "^1.1.13",
-        "@inquirer/input": "^1.2.13",
-        "@inquirer/password": "^1.1.13",
-        "@inquirer/rawlist": "^1.2.13",
-        "@inquirer/select": "^1.3.0"
+        "@inquirer/checkbox": "^2.2.1",
+        "@inquirer/confirm": "^3.1.1",
+        "@inquirer/core": "^7.1.1",
+        "@inquirer/editor": "^2.1.1",
+        "@inquirer/expand": "^2.1.1",
+        "@inquirer/input": "^2.1.1",
+        "@inquirer/password": "^2.1.1",
+        "@inquirer/rawlist": "^2.1.1",
+        "@inquirer/select": "^2.2.1"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=18"
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-1.2.13.tgz",
-      "integrity": "sha512-f+bASrCY2x2F90MrBYX7nUSetL6FsVLfskhGWEyVwj6VIXzc9T878z3v7KU3V10D1trWrCVHOdeqEcbnO68yhg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-2.1.1.tgz",
+      "integrity": "sha512-PIpJdNqVhjnl2bDz8iUKqMmgGdspN4s7EZiuNPnNrqZLP+LRUDDHVyd7X7xjiEMulBt3lt2id4SjTbra+v/Ajg==",
       "dependencies": {
-        "@inquirer/core": "^5.1.0",
-        "@inquirer/type": "^1.1.5",
+        "@inquirer/core": "^7.1.1",
+        "@inquirer/type": "^1.2.1",
         "chalk": "^4.1.2"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/rawlist/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-1.3.0.tgz",
-      "integrity": "sha512-3sL5odCDYI+i+piAFqFa5ULDUKEpc0U1zEY4Wm6gjP6nMAHWM8r1UzMlpQXCyHny91Tz+oeSLeKinAde0z6R7w==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-2.2.1.tgz",
+      "integrity": "sha512-JR4FeHvuxPSPWQy8DzkIvoIsJ4SWtSFb4xVLvLto84dL+jkv12lm8ILtuax4bMHvg5MBj3wYUF6Tk9izJ07gdw==",
       "dependencies": {
-        "@inquirer/core": "^5.1.0",
-        "@inquirer/type": "^1.1.5",
+        "@inquirer/core": "^7.1.1",
+        "@inquirer/type": "^1.2.1",
         "ansi-escapes": "^4.3.2",
         "chalk": "^4.1.2",
         "figures": "^3.2.0"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/select/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.1.5.tgz",
-      "integrity": "sha512-wmwHvHozpPo4IZkkNtbYenem/0wnfI6hvOcGKmPEa0DwuaH5XUQzFqy6OpEpjEegZMhYIk8HDYITI16BPLtrRA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.2.1.tgz",
+      "integrity": "sha512-xwMfkPAxeo8Ji/IxfUSqzRi0/+F2GIqJmpc5/thelgMGsjNZcjDDRBO9TLXT1s/hdx/mK5QbVIvgoLIFgXhTMQ==",
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=18"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -1704,134 +1421,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "14.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.1.4.tgz",
-      "integrity": "sha512-b0Xo1ELj3u7IkZWAKcJPJEhBop117U78l70nfoQGo4xUSvv0PJSTaV4U9xQBLvZlnjsYkc8RwQN1HoH/oQmLlQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.1.4.tgz",
-      "integrity": "sha512-457G0hcLrdYA/u1O2XkRMsDKId5VKe3uKPvrKVOyuARa6nXrdhJOOYU9hkKKyQTMru1B8qEP78IAhf/1XnVqKA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.1.4.tgz",
-      "integrity": "sha512-l/kMG+z6MB+fKA9KdtyprkTQ1ihlJcBh66cf0HvqGP+rXBbOXX0dpJatjZbHeunvEHoBBS69GYQG5ry78JMy3g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.1.4.tgz",
-      "integrity": "sha512-BapIFZ3ZRnvQ1uWbmqEGJuPT9cgLwvKtxhK/L2t4QYO7l+/DxXuIGjvp1x8rvfa/x1FFSsipERZK70pewbtJtw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.1.4.tgz",
-      "integrity": "sha512-mqVxTwk4XuBl49qn2A5UmzFImoL1iLm0KQQwtdRJRKl21ylQwwGCxJtIYo2rbfkZHoSKlh/YgztY0qH3wG1xIg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.1.4.tgz",
-      "integrity": "sha512-xzxF4ErcumXjO2Pvg/wVGrtr9QQJLk3IyQX1ddAC/fi6/5jZCZ9xpuL9Tzc4KPWMFq8GGWFVDMshZOdHGdkvag==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.1.4.tgz",
-      "integrity": "sha512-WZiz8OdbkpRw6/IU/lredZWKKZopUMhcI2F+XiMAcPja0uZYdMTZQRoQ0WZcvinn9xZAidimE7tN9W5v9Yyfyw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.1.4.tgz",
-      "integrity": "sha512-4Rto21sPfw555sZ/XNLqfxDUNeLhNYGO2dlPqsnuCg8N8a2a9u1ltqBOPQ4vj1Gf7eJC0W2hHG2eYUHuiXgY2w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -2514,9 +2103,9 @@
       }
     },
     "node_modules/@types/dotenv-flow": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@types/dotenv-flow/-/dotenv-flow-3.3.1.tgz",
-      "integrity": "sha512-z4W5zC6mx9j1OGV+cUDoyLqYkh09BCUq64+TPwnmWpqXQs39DpegWtFQBzvNDdjeXhzW9Xvuy+z1Fn2RSkfTfA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@types/dotenv-flow/-/dotenv-flow-3.3.3.tgz",
+      "integrity": "sha512-aJjBsKw4bfGjvaRwrxBtEOfYZxCAq+LiFTpZ4DGTEK2b9eLVt/IAClapSxMfgV4Mi/2bIBKKjoTCO0lOh4ACLg==",
       "dev": true
     },
     "node_modules/@types/istanbul-lib-coverage": {
@@ -2526,19 +2115,19 @@
       "dev": true
     },
     "node_modules/@types/mute-stream": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.2.tgz",
-      "integrity": "sha512-FpiGjk6+IOrN0lZEfUUjdra1csU1VxwYFj4S0Zj+TJpu5x5mZW30RkEZojTadrNZHNmpCHgoE62IQZAH0OeuIA==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
+      "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/node": {
-      "version": "20.8.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.4.tgz",
-      "integrity": "sha512-ZVPnqU58giiCjSxjVUESDtdPk4QR5WQhhINbc9UBrKLU68MX5BF6kbQzTrkwbolyr0X8ChBpXfavr5mZFKZQ5A==",
+      "version": "20.12.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.3.tgz",
+      "integrity": "sha512-sD+ia2ubTeWrOu+YMF+MTAB7E+O7qsMqAbMfW7DG3K1URwhZ5hN1pLlRVGbf4wDFzSfikL05M17EyorS86jShw==",
       "dependencies": {
-        "undici-types": "~5.25.1"
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/@types/node-fetch": {
@@ -2559,9 +2148,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "18.2.27",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.27.tgz",
-      "integrity": "sha512-Wfv7B7FZiR2r3MIqbAlXoY1+tXm4bOqfz4oRr+nyXdBqapDBZ0l/IGcSlAfvxIHEEJjkPU0MYAc/BlFPOcrgLw==",
+      "version": "18.2.42",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.42.tgz",
+      "integrity": "sha512-c1zEr96MjakLYus/wPnuWDo1/zErfdU9rNsIGmE+NV71nx88FG9Ttgo5dqorXTu/LImX2f63WBP986gJkMPNbA==",
       "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -2570,9 +2159,10 @@
       }
     },
     "node_modules/@types/scheduler": {
-      "version": "0.16.3",
-      "devOptional": true,
-      "license": "MIT"
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-YIoDCTH3Af6XM5VuwGG/QL/CJqga1Zm3NkU3HZ4ZHK2fRMPYP1VczsTUqtsf43PH/iJNVlPHAo2oWX7BSdB2Hw==",
+      "devOptional": true
     },
     "node_modules/@types/wrap-ansi": {
       "version": "3.0.0",
@@ -2580,9 +2170,9 @@
       "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g=="
     },
     "node_modules/@types/yargs": {
-      "version": "17.0.28",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.28.tgz",
-      "integrity": "sha512-N3e3fkS86hNhtk6BEnc0rj3zcehaxx8QWhCROJkqpl5Zaoi7nAic3jH8q94jVD3zu5LGk+PUB6KAiDmimYOEQw==",
+      "version": "17.0.32",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
+      "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -2627,6 +2217,17 @@
       ],
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@vercel/blob/node_modules/undici": {
+      "version": "5.28.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.3.tgz",
+      "integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@zkochan/rimraf": {
@@ -2859,15 +2460,11 @@
       }
     },
     "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
       "engines": {
-        "node": ">=10"
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
@@ -2909,9 +2506,9 @@
       }
     },
     "node_modules/cli-spinners": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.1.tgz",
-      "integrity": "sha512-jHgecW0pxkonBJdrKsqxgRX9AcG+u/5k0Q7WPDfi8AogLAdwxEkyYYNWwZ5GvVFoFx2uiY1eNcSK00fh+1+FyQ==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
       "engines": {
         "node": ">=6"
       },
@@ -4198,14 +3795,6 @@
         "node": "*"
       }
     },
-    "node_modules/run-async": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
-      "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "license": "MIT"
@@ -4538,54 +4127,6 @@
         "fsevents": "~2.3.3"
       }
     },
-    "node_modules/tsx/node_modules/@esbuild/android-arm": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
-      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
-      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/android-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
-      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
       "version": "0.18.20",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
@@ -4597,294 +4138,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
-      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
-      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
-      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
-      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
-      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
-      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
-      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
-      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
-      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
-      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
-      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
-      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
-      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
-      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
-      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
-      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
-      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
-      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -4939,9 +4192,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
+      "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -4952,20 +4205,17 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.28.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.3.tgz",
-      "integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.11.1.tgz",
+      "integrity": "sha512-KyhzaLJnV1qa3BSHdj4AZ2ndqI0QWPxYzaIOio0WzcEJB9gvuysprJSLtpvc2D9mhR9jPDUk7xlJlZbH2KR5iw==",
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.0"
       }
     },
     "node_modules/undici-types": {
-      "version": "5.25.3",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
-      "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA=="
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/universalify": {
       "version": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "0.17.1",
       "license": "MIT",
       "dependencies": {
-        "@aws-sdk/client-s3": "~3.437.0",
+        "@aws-sdk/client-s3": "~3.540.0",
         "@inquirer/prompts": "^3.2.0",
         "@mux/mux-node": "8.2.3",
-        "@mux/mux-player-react": "2.4.0",
-        "@mux/mux-video-react": "^0.8.4",
+        "@mux/mux-player-react": "2.4.1",
+        "@mux/mux-video-react": "^0.8.5",
         "@next/env": "^14.1.4",
         "@paralleldrive/cuid2": "^2.2.2",
         "@vercel/blob": "^0.22.1",
@@ -182,849 +182,610 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.437.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.437.0.tgz",
-      "integrity": "sha512-KCocXvRH3pCTJNeNivDJN9mygK0B4Uvp5POWlCXgOj5iQU2U/sEpr+LqAwQZiZZjE7crcsAf0FPKMyk6/oMXHQ==",
+      "version": "3.540.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.540.0.tgz",
+      "integrity": "sha512-rYBuNB7uqCO9xZc0OAwM2K6QJAo2Syt1L5OhEaf7zG7FulNMyrK6kJPg1WrvNE90tW6gUdDaTy3XsQ7lq6O7uA==",
       "dependencies": {
         "@aws-crypto/sha1-browser": "3.0.0",
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.437.0",
-        "@aws-sdk/core": "3.436.0",
-        "@aws-sdk/credential-provider-node": "3.437.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.433.0",
-        "@aws-sdk/middleware-expect-continue": "3.433.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.433.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-location-constraint": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-sdk-s3": "3.433.0",
-        "@aws-sdk/middleware-signing": "3.433.0",
-        "@aws-sdk/middleware-ssec": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.433.0",
-        "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/signature-v4-multi-region": "3.437.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.433.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.437.0",
-        "@aws-sdk/xml-builder": "3.310.0",
-        "@smithy/config-resolver": "^2.0.16",
-        "@smithy/eventstream-serde-browser": "^2.0.12",
-        "@smithy/eventstream-serde-config-resolver": "^2.0.12",
-        "@smithy/eventstream-serde-node": "^2.0.12",
-        "@smithy/fetch-http-handler": "^2.2.4",
-        "@smithy/hash-blob-browser": "^2.0.12",
-        "@smithy/hash-node": "^2.0.12",
-        "@smithy/hash-stream-node": "^2.0.12",
-        "@smithy/invalid-dependency": "^2.0.12",
-        "@smithy/md5-js": "^2.0.12",
-        "@smithy/middleware-content-length": "^2.0.14",
-        "@smithy/middleware-endpoint": "^2.1.3",
-        "@smithy/middleware-retry": "^2.0.18",
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.16",
-        "@smithy/util-defaults-mode-node": "^2.0.21",
-        "@smithy/util-retry": "^2.0.5",
-        "@smithy/util-stream": "^2.0.17",
-        "@smithy/util-utf8": "^2.0.0",
-        "@smithy/util-waiter": "^2.0.12",
-        "fast-xml-parser": "4.2.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/types": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
-      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/client-sts": "3.540.0",
+        "@aws-sdk/core": "3.535.0",
+        "@aws-sdk/credential-provider-node": "3.540.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.535.0",
+        "@aws-sdk/middleware-expect-continue": "3.535.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.535.0",
+        "@aws-sdk/middleware-host-header": "3.535.0",
+        "@aws-sdk/middleware-location-constraint": "3.535.0",
+        "@aws-sdk/middleware-logger": "3.535.0",
+        "@aws-sdk/middleware-recursion-detection": "3.535.0",
+        "@aws-sdk/middleware-sdk-s3": "3.535.0",
+        "@aws-sdk/middleware-signing": "3.535.0",
+        "@aws-sdk/middleware-ssec": "3.537.0",
+        "@aws-sdk/middleware-user-agent": "3.540.0",
+        "@aws-sdk/region-config-resolver": "3.535.0",
+        "@aws-sdk/signature-v4-multi-region": "3.535.0",
+        "@aws-sdk/types": "3.535.0",
+        "@aws-sdk/util-endpoints": "3.540.0",
+        "@aws-sdk/util-user-agent-browser": "3.535.0",
+        "@aws-sdk/util-user-agent-node": "3.535.0",
+        "@aws-sdk/xml-builder": "3.535.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.0",
+        "@smithy/eventstream-serde-browser": "^2.2.0",
+        "@smithy/eventstream-serde-config-resolver": "^2.2.0",
+        "@smithy/eventstream-serde-node": "^2.2.0",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-blob-browser": "^2.2.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/hash-stream-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/md5-js": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.0",
+        "@smithy/middleware-retry": "^2.2.0",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.0",
+        "@smithy/util-defaults-mode-node": "^2.3.0",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-stream": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "@smithy/util-waiter": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.437.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.437.0.tgz",
-      "integrity": "sha512-AxlLWz9ec3b8Bt+RqRb2Q1ucGQtKrLdKDna+UTjz7AouB/jpoMiegV9NHXVX64N6YFnQnvB0UEGigXiOQE+y/g==",
+      "version": "3.540.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.540.0.tgz",
+      "integrity": "sha512-rrQZMuw4sxIo3eyAUUzPQRA336mPRnrAeSlSdVHBKZD8Fjvoy0lYry2vNhkPLpFZLso1J66KRyuIv4LzRR3v1Q==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/core": "3.436.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.433.0",
-        "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.433.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.437.0",
-        "@smithy/config-resolver": "^2.0.16",
-        "@smithy/fetch-http-handler": "^2.2.4",
-        "@smithy/hash-node": "^2.0.12",
-        "@smithy/invalid-dependency": "^2.0.12",
-        "@smithy/middleware-content-length": "^2.0.14",
-        "@smithy/middleware-endpoint": "^2.1.3",
-        "@smithy/middleware-retry": "^2.0.18",
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.16",
-        "@smithy/util-defaults-mode-node": "^2.0.21",
-        "@smithy/util-retry": "^2.0.5",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/core": "3.535.0",
+        "@aws-sdk/middleware-host-header": "3.535.0",
+        "@aws-sdk/middleware-logger": "3.535.0",
+        "@aws-sdk/middleware-recursion-detection": "3.535.0",
+        "@aws-sdk/middleware-user-agent": "3.540.0",
+        "@aws-sdk/region-config-resolver": "3.535.0",
+        "@aws-sdk/types": "3.535.0",
+        "@aws-sdk/util-endpoints": "3.540.0",
+        "@aws-sdk/util-user-agent-browser": "3.535.0",
+        "@aws-sdk/util-user-agent-node": "3.535.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.0",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.0",
+        "@smithy/middleware-retry": "^2.2.0",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.0",
+        "@smithy/util-defaults-mode-node": "^2.3.0",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/types": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
-      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
+    "node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.540.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.540.0.tgz",
+      "integrity": "sha512-LZYK0lBRQK8D8M3Sqc96XiXkAV2v70zhTtF6weyzEpgwxZMfSuFJjs0jFyhaeZBZbZv7BBghIdhJ5TPavNxGMQ==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.540.0",
+        "@aws-sdk/core": "3.535.0",
+        "@aws-sdk/middleware-host-header": "3.535.0",
+        "@aws-sdk/middleware-logger": "3.535.0",
+        "@aws-sdk/middleware-recursion-detection": "3.535.0",
+        "@aws-sdk/middleware-user-agent": "3.540.0",
+        "@aws-sdk/region-config-resolver": "3.535.0",
+        "@aws-sdk/types": "3.535.0",
+        "@aws-sdk/util-endpoints": "3.540.0",
+        "@aws-sdk/util-user-agent-browser": "3.535.0",
+        "@aws-sdk/util-user-agent-node": "3.535.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.0",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.0",
+        "@smithy/middleware-retry": "^2.2.0",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.0",
+        "@smithy/util-defaults-mode-node": "^2.3.0",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": "^3.540.0"
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.437.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.437.0.tgz",
-      "integrity": "sha512-ilLcrCVwH81UbKNpB9Vax1Fw/mNx2d/bWXkCNXPvrExO+K39VFGS/VijOuSrru2iBq844NlG3uQV8DL/nbiKdA==",
+      "version": "3.540.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.540.0.tgz",
+      "integrity": "sha512-ITHUQxvpqfQX6obfpIi3KYGzZYfe/I5Ixjfxoi5lB7ISCtmxqObKB1fzD93wonkMJytJ7LUO8panZl/ojiJ1uw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/core": "3.436.0",
-        "@aws-sdk/credential-provider-node": "3.437.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-sdk-sts": "3.433.0",
-        "@aws-sdk/middleware-signing": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.433.0",
-        "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.433.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.437.0",
-        "@smithy/config-resolver": "^2.0.16",
-        "@smithy/fetch-http-handler": "^2.2.4",
-        "@smithy/hash-node": "^2.0.12",
-        "@smithy/invalid-dependency": "^2.0.12",
-        "@smithy/middleware-content-length": "^2.0.14",
-        "@smithy/middleware-endpoint": "^2.1.3",
-        "@smithy/middleware-retry": "^2.0.18",
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.16",
-        "@smithy/util-defaults-mode-node": "^2.0.21",
-        "@smithy/util-retry": "^2.0.5",
-        "@smithy/util-utf8": "^2.0.0",
-        "fast-xml-parser": "4.2.5",
-        "tslib": "^2.5.0"
+        "@aws-sdk/core": "3.535.0",
+        "@aws-sdk/middleware-host-header": "3.535.0",
+        "@aws-sdk/middleware-logger": "3.535.0",
+        "@aws-sdk/middleware-recursion-detection": "3.535.0",
+        "@aws-sdk/middleware-user-agent": "3.540.0",
+        "@aws-sdk/region-config-resolver": "3.535.0",
+        "@aws-sdk/types": "3.535.0",
+        "@aws-sdk/util-endpoints": "3.540.0",
+        "@aws-sdk/util-user-agent-browser": "3.535.0",
+        "@aws-sdk/util-user-agent-node": "3.535.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.0",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.0",
+        "@smithy/middleware-retry": "^2.2.0",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.0",
+        "@smithy/util-defaults-mode-node": "^2.3.0",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/types": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
-      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
       },
-      "engines": {
-        "node": ">=14.0.0"
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": "^3.540.0"
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.436.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.436.0.tgz",
-      "integrity": "sha512-vX5/LjXvCejC2XUY6TSg1oozjqK6BvkE75t0ys9dgqyr5PlZyZksMoeAFHUlj0sCjhT3ziWCujP1oiSpPWY9hg==",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.535.0.tgz",
+      "integrity": "sha512-+Yusa9HziuaEDta1UaLEtMAtmgvxdxhPn7jgfRY6PplqAqgsfa5FR83sxy5qr2q7xjQTwHtV4MjQVuOjG9JsLw==",
       "dependencies": {
-        "@smithy/smithy-client": "^2.1.12"
+        "@smithy/core": "^1.4.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/signature-v4": "^2.2.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.433.0.tgz",
-      "integrity": "sha512-Vl7Qz5qYyxBurMn6hfSiNJeUHSqfVUlMt0C1Bds3tCkl3IzecRWwyBOlxtxO3VCrgVeW3HqswLzCvhAFzPH6nQ==",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.535.0.tgz",
+      "integrity": "sha512-XppwO8c0GCGSAvdzyJOhbtktSEaShg14VJKg8mpMa1XcgqzmcqqHQjtDWbx5rZheY1VdpXZhpEzJkB6LpQejpA==",
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-env/node_modules/@aws-sdk/types": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
-      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.535.0.tgz",
+      "integrity": "sha512-kdj1wCmOMZ29jSlUskRqN04S6fJ4dvt0Nq9Z32SA6wO7UG8ht6Ot9h/au/eTWJM3E1somZ7D771oK7dQt9b8yw==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-stream": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.437.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.437.0.tgz",
-      "integrity": "sha512-UybiJxYPvdwok5OcI9LakaHmaWZBdkX0gY8yU2n7TomYgWOwDJ88MpQgjXUJJ249PH+9/+How5H3vnFp0xJ0uQ==",
+      "version": "3.540.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.540.0.tgz",
+      "integrity": "sha512-igN/RbsnulIBwqXbwsWmR3srqmtbPF1dm+JteGvUY31FW65fTVvWvSr945Y/cf1UbhPmIQXntlsqESqpkhTHwg==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.433.0",
-        "@aws-sdk/credential-provider-process": "3.433.0",
-        "@aws-sdk/credential-provider-sso": "3.437.0",
-        "@aws-sdk/credential-provider-web-identity": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/credential-provider-imds": "^2.0.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/types": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
-      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/client-sts": "3.540.0",
+        "@aws-sdk/credential-provider-env": "3.535.0",
+        "@aws-sdk/credential-provider-process": "3.535.0",
+        "@aws-sdk/credential-provider-sso": "3.540.0",
+        "@aws-sdk/credential-provider-web-identity": "3.540.0",
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/credential-provider-imds": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.437.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.437.0.tgz",
-      "integrity": "sha512-FMtgEe/me68xZQsymEpMcw7OuuiHaHx/Tp5EqZP5FC0Yv1yX3qr/ncIWU2zY3a9K0iLERmzQI1g3CMd8r4sy8A==",
+      "version": "3.540.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.540.0.tgz",
+      "integrity": "sha512-HKQZJbLHlrHX9A0B1poiYNXIIQfy8whTjuosTCYKPDBhhUyVAQfxy/KG726j0v43IhaNPLgTGZCJve4hAsazSw==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.433.0",
-        "@aws-sdk/credential-provider-ini": "3.437.0",
-        "@aws-sdk/credential-provider-process": "3.433.0",
-        "@aws-sdk/credential-provider-sso": "3.437.0",
-        "@aws-sdk/credential-provider-web-identity": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/credential-provider-imds": "^2.0.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/types": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
-      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/credential-provider-env": "3.535.0",
+        "@aws-sdk/credential-provider-http": "3.535.0",
+        "@aws-sdk/credential-provider-ini": "3.540.0",
+        "@aws-sdk/credential-provider-process": "3.535.0",
+        "@aws-sdk/credential-provider-sso": "3.540.0",
+        "@aws-sdk/credential-provider-web-identity": "3.540.0",
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/credential-provider-imds": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.433.0.tgz",
-      "integrity": "sha512-W7FcGlQjio9Y/PepcZGRyl5Bpwb0uWU7qIUCh+u4+q2mW4D5ZngXg8V/opL9/I/p4tUH9VXZLyLGwyBSkdhL+A==",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.535.0.tgz",
+      "integrity": "sha512-9O1OaprGCnlb/kYl8RwmH7Mlg8JREZctB8r9sa1KhSsWFq/SWO0AuJTyowxD7zL5PkeS4eTvzFFHWCa3OO5epA==",
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-process/node_modules/@aws-sdk/types": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
-      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.437.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.437.0.tgz",
-      "integrity": "sha512-kijtnyyA6/+ipOef4KACsLDUTFWDZ97DSWKU0hJFyGEfelaon6o7NNVufuVOWrBNyklNWZqvPLuwWWQCxb6fuQ==",
+      "version": "3.540.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.540.0.tgz",
+      "integrity": "sha512-tKkFqK227LF5ajc5EL6asXS32p3nkofpP8G7NRpU7zOEOQCg01KUc4JRX+ItI0T007CiN1J19yNoFqHLT/SqHg==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.437.0",
-        "@aws-sdk/token-providers": "3.437.0",
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/types": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
-      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/client-sso": "3.540.0",
+        "@aws-sdk/token-providers": "3.540.0",
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.433.0.tgz",
-      "integrity": "sha512-RlwjP1I5wO+aPpwyCp23Mk8nmRbRL33hqRASy73c4JA2z2YiRua+ryt6MalIxehhwQU6xvXUKulJnPG9VaMFZg==",
+      "version": "3.540.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.540.0.tgz",
+      "integrity": "sha512-OpDm9w3A168B44hSjpnvECP4rvnFzD86rN4VYdGADuCvEa5uEcdA/JuT5WclFPDqdWEmFBqS1pxBIJBf0g2Q9Q==",
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@aws-sdk/types": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
-      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/client-sts": "3.540.0",
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.433.0.tgz",
-      "integrity": "sha512-Lk1xIu2tWTRa1zDw5hCF1RrpWQYSodUhrS/q3oKz8IAoFqEy+lNaD5jx+fycuZb5EkE4IzWysT+8wVkd0mAnOg==",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.535.0.tgz",
+      "integrity": "sha512-7sijlfQsc4UO9Fsl11mU26Y5f9E7g6UoNg/iJUBpC5pgvvmdBRO5UEhbB/gnqvOEPsBXyhmfzbstebq23Qdz7A==",
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-arn-parser": "3.310.0",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-config-provider": "^2.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@aws-sdk/types": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
-      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@aws-sdk/util-arn-parser": "3.535.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-config-provider": "^2.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.433.0.tgz",
-      "integrity": "sha512-Uq2rPIsjz0CR2sulM/HyYr5WiqiefrSRLdwUZuA7opxFSfE808w5DBWSprHxbH3rbDSQR4nFiOiVYIH8Eth7nA==",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.535.0.tgz",
+      "integrity": "sha512-hFKyqUBky0NWCVku8iZ9+PACehx0p6vuMw5YnZf8FVgHP0fode0b/NwQY6UY7oor/GftvRsAlRUAWGNFEGUpwA==",
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-expect-continue/node_modules/@aws-sdk/types": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
-      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.433.0.tgz",
-      "integrity": "sha512-Ptssx373+I7EzFUWjp/i/YiNFt6I6sDuRHz6DOUR9nmmRTlHHqmdcBXlJL2d9wwFxoBRCN8/PXGsTc/DJ4c95Q==",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.535.0.tgz",
+      "integrity": "sha512-rBIzldY9jjRATxICDX7t77aW6ctqmVDgnuAOgbVT5xgHftt4o7PGWKoMvl/45hYqoQgxVFnCBof9bxkqSBebVA==",
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
         "@aws-crypto/crc32c": "3.0.0",
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/is-array-buffer": "^2.0.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/types": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
-      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/is-array-buffer": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.433.0.tgz",
-      "integrity": "sha512-mBTq3UWv1UzeHG+OfUQ2MB/5GEkt5LTKFaUqzL7ESwzW8XtpBgXnjZvIwu3Vcd3sEetMwijwaGiJhY0ae/YyaA==",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.535.0.tgz",
+      "integrity": "sha512-0h6TWjBWtDaYwHMQJI9ulafeS4lLaw1vIxRjbpH0svFRt6Eve+Sy8NlVhECfTU2hNz/fLubvrUxsXoThaLBIew==",
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-host-header/node_modules/@aws-sdk/types": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
-      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.433.0.tgz",
-      "integrity": "sha512-2YD860TGntwZifIUbxm+lFnNJJhByR/RB/+fV1I8oGKg+XX2rZU+94pRfHXRywoZKlCA0L+LGDA1I56jxrB9sw==",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.535.0.tgz",
+      "integrity": "sha512-SxfS9wfidUZZ+WnlKRTCRn3h+XTsymXRXPJj8VV6hNRNeOwzNweoG3YhQbTowuuNfXf89m9v6meYkBBtkdacKw==",
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-location-constraint/node_modules/@aws-sdk/types": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
-      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.433.0.tgz",
-      "integrity": "sha512-We346Fb5xGonTGVZC9Nvqtnqy74VJzYuTLLiuuftA5sbNzftBDy/22QCfvYSTOAl3bvif+dkDUzQY2ihc5PwOQ==",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.535.0.tgz",
+      "integrity": "sha512-huNHpONOrEDrdRTvSQr1cJiRMNf0S52NDXtaPzdxiubTkP+vni2MohmZANMOai/qT0olmEVX01LhZ0ZAOgmg6A==",
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-logger/node_modules/@aws-sdk/types": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
-      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.433.0.tgz",
-      "integrity": "sha512-HEvYC9PQlWY/ccUYtLvAlwwf1iCif2TSAmLNr3YTBRVa98x6jKL0hlCrHWYklFeqOGSKy6XhE+NGJMUII0/HaQ==",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.535.0.tgz",
+      "integrity": "sha512-am2qgGs+gwqmR4wHLWpzlZ8PWhm4ktj5bYSgDrsOfjhdBlWNxvPoID9/pDAz5RWL48+oH7I6SQzMqxXsFDikrw==",
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@aws-sdk/types": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
-      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.433.0.tgz",
-      "integrity": "sha512-mkn3DiSuMVh4NTLsduC42Av+ApcOor52LMoQY0Wc6M5Mx7Xd05U+G1j8sjI9n/1bs5cZ/PoeRYJ/9bL1Xxznnw==",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.535.0.tgz",
+      "integrity": "sha512-/dLG/E3af6ohxkQ5GBHT8tZfuPIg6eItKxCXuulvYj0Tqgf3Mb+xTsvSkxQsJF06RS4sH7Qsg/PnB8ZfrJrXpg==",
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-arn-parser": "3.310.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/types": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
-      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.433.0.tgz",
-      "integrity": "sha512-ORYbJnBejUyonFl5FwIqhvI3Cq6sAp9j+JpkKZtFNma9tFPdrhmYgfCeNH32H/wGTQV/tUoQ3luh0gA4cuk6DA==",
-      "dependencies": {
-        "@aws-sdk/middleware-signing": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@aws-sdk/types": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
-      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@aws-sdk/util-arn-parser": "3.535.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/signature-v4": "^2.2.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-config-provider": "^2.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.433.0.tgz",
-      "integrity": "sha512-jxPvt59NZo/epMNLNTu47ikmP8v0q217I6bQFGJG7JVFnfl36zDktMwGw+0xZR80qiK47/2BWrNpta61Zd2FxQ==",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.535.0.tgz",
+      "integrity": "sha512-Rb4sfus1Gc5paRl9JJgymJGsb/i3gJKK/rTuFZICdd1PBBE5osIOHP5CpzWYBtc5LlyZE1a2QoxPMCyG+QUGPw==",
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/signature-v4": "^2.0.0",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-middleware": "^2.0.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-signing/node_modules/@aws-sdk/types": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
-      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/signature-v4": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.433.0.tgz",
-      "integrity": "sha512-2AMaPx0kYfCiekxoL7aqFqSSoA9du+yI4zefpQNLr+1cZOerYiDxdsZ4mbqStR1CVFaX6U6hrYokXzjInsvETw==",
+      "version": "3.537.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.537.0.tgz",
+      "integrity": "sha512-2QWMrbwd5eBy5KCYn9a15JEWBgrK2qFEKQN2lqb/6z0bhtevIOxIRfC99tzvRuPt6nixFQ+ynKuBjcfT4ZFrdQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-ssec/node_modules/@aws-sdk/types": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
-      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.433.0.tgz",
-      "integrity": "sha512-jMgA1jHfisBK4oSjMKrtKEZf0sl2vzADivkFmyZFzORpSZxBnF6hC21RjaI+70LJLcc9rSCzLgcoz5lHb9LLDg==",
+      "version": "3.540.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.540.0.tgz",
+      "integrity": "sha512-8Rd6wPeXDnOYzWj1XCmOKcx/Q87L0K1/EHqOBocGjLVbN3gmRxBvpmR1pRTjf7IsWfnnzN5btqtcAkfDPYQUMQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.433.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/types": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
-      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@aws-sdk/util-endpoints": "3.540.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.433.0.tgz",
-      "integrity": "sha512-xpjRjCZW+CDFdcMmmhIYg81ST5UAnJh61IHziQEk0FXONrg4kjyYPZAOjEdzXQ+HxJQuGQLKPhRdzxmQnbX7pg==",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.535.0.tgz",
+      "integrity": "sha512-IXOznDiaItBjsQy4Fil0kzX/J3HxIOknEphqHbOfUf+LpA5ugcsxuQQONrbEQusCBnfJyymrldBvBhFmtlU9Wg==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-config-provider": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.5",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-config-provider": "^2.3.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.437.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.437.0.tgz",
-      "integrity": "sha512-MmrqudssOs87JgVg7HGVdvJws/t4kcOrJJd+975ki+DPeSoyK2U4zBDfDkJ+n0tFuZBs3sLwLh0QXE7BV28rRA==",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.535.0.tgz",
+      "integrity": "sha512-tqCsEsEj8icW0SAh3NvyhRUq54Gz2pu4NM2tOSrFp7SO55heUUaRLSzYteNZCTOupH//AAaZvbN/UUTO/DrOog==",
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/signature-v4": "^2.0.0",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/types": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
-      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/middleware-sdk-s3": "3.535.0",
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/signature-v4": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.437.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.437.0.tgz",
-      "integrity": "sha512-nV9qIuG0+6XJb7hWpCC+/K7RoY3PZUWndP8BRQv7PQhhpd8tG/I5Kxb0V83h2XFBXyyjnv0aOHO8ehz3Kfcv2Q==",
+      "version": "3.540.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.540.0.tgz",
+      "integrity": "sha512-9BvtiVEZe5Ev88Wa4ZIUbtT6BVcPwhxmVInQ6c12MYNb0WNL54BN6wLy/eknAfF05gpX2/NDU2pUDOyMPdm/+g==",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.433.0",
-        "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.433.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.437.0",
-        "@smithy/config-resolver": "^2.0.16",
-        "@smithy/fetch-http-handler": "^2.2.4",
-        "@smithy/hash-node": "^2.0.12",
-        "@smithy/invalid-dependency": "^2.0.12",
-        "@smithy/middleware-content-length": "^2.0.14",
-        "@smithy/middleware-endpoint": "^2.1.3",
-        "@smithy/middleware-retry": "^2.0.18",
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.16",
-        "@smithy/util-defaults-mode-node": "^2.0.21",
-        "@smithy/util-retry": "^2.0.5",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/types": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
-      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/client-sso-oidc": "3.540.0",
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.460.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.460.0.tgz",
-      "integrity": "sha512-MyZSWS/FV8Bnux5eD9en7KLgVxevlVrGNEP3X2D7fpnUlLhl0a7k8+OpSI2ozEQB8hIU2DLc/XXTKRerHSefxQ==",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
+      "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
       "dependencies": {
-        "@smithy/types": "^2.5.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.310.0.tgz",
-      "integrity": "sha512-jL8509owp/xB9+Or0pvn3Fe+b94qfklc2yPowZZIFAkFcCSIdkIglz18cPDWnYAcy9JGewpMS1COXKIUhZkJsA==",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.535.0.tgz",
+      "integrity": "sha512-smVo29nUPAOprp8Z5Y3GHuhiOtw6c8/EtLCm5AVMtRsTPw4V414ZXL2H66tzmb5kEeSzQlbfBSBEdIFZoxO9kg==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.433.0.tgz",
-      "integrity": "sha512-LFNUh9FH7RMtYjSjPGz9lAJQMzmJ3RcXISzc5X5k2R/9mNwMK7y1k2VAfvx+RbuDbll6xwsXlgv6QHcxVdF2zw==",
+      "version": "3.540.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.540.0.tgz",
+      "integrity": "sha512-1kMyQFAWx6f8alaI6UT65/5YW/7pDWAKAdNwL6vuJLea03KrZRX3PMoONOSJpAS5m3Ot7HlWZvf3wZDNTLELZw==",
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-endpoints/node_modules/@aws-sdk/types": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
-      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-endpoints": "^1.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1042,37 +803,25 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.433.0.tgz",
-      "integrity": "sha512-2Cf/Lwvxbt5RXvWFXrFr49vXv0IddiUwrZoAiwhDYxvsh+BMnh+NUFot+ZQaTrk/8IPZVDeLPWZRdVy00iaVXQ==",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.535.0.tgz",
+      "integrity": "sha512-RWMcF/xV5n+nhaA/Ff5P3yNP3Kur/I+VNZngog4TEs92oB/nwOdAg/2JL8bVAhUbMrjTjpwm7PItziYFQoqyig==",
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/types": "^2.4.0",
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/types": "^2.12.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-user-agent-browser/node_modules/@aws-sdk/types": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
-      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.437.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.437.0.tgz",
-      "integrity": "sha512-JVEcvWaniamtYVPem4UthtCNoTBCfFTwYj7Y3CrWZ2Qic4TqrwLkAfaBGtI2TGrhIClVr77uzLI6exqMTN7orA==",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.535.0.tgz",
+      "integrity": "sha512-dRek0zUuIT25wOWJlsRm97nTkUlh1NDcLsQZIN2Y8KxhwoXXWtJs5vaDPT+qAg+OpcNj80i1zLR/CirqlFg/TQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1086,18 +835,6 @@
         }
       }
     },
-    "node_modules/@aws-sdk/util-user-agent-node/node_modules/@aws-sdk/types": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
-      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/util-utf8-browser": {
       "version": "3.259.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
@@ -1107,11 +844,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.310.0.tgz",
-      "integrity": "sha512-TqELu4mOuSIKQCqj63fGVs86Yh+vBx5nHRpWKNUNhB2nPTpfbziTs5c1X358be3peVWA4wPxW7Nt53KIg1tnNw==",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.535.0.tgz",
+      "integrity": "sha512-VXAq/Jz8KIrU84+HqsOJhIKZqG0PNTdi6n6PFQ4xJf44ZQHD/5C7ouH4qCFX5XgZXcgbRIcMVVYGC6Jye0dRng==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1876,22 +1614,22 @@
       }
     },
     "node_modules/@mux/mux-player": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@mux/mux-player/-/mux-player-2.4.0.tgz",
-      "integrity": "sha512-6F6RvXyIWwYtwh29+bmoqa5Nd1z31wGafeKtIds0BYP+PdVYRSRhQ16B8tajUb0+yeCVbqyvBnITEUoAZ0zuIQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@mux/mux-player/-/mux-player-2.4.1.tgz",
+      "integrity": "sha512-Lm7KkG/lD1tqqqtL1nacZsCll9JY4gVNGxUw/MPYmgIevYACYtQ/76iaEtaN67DmHYYxep1QUpYEDZPXallkEg==",
       "dependencies": {
-        "@mux/mux-video": "0.17.4",
-        "@mux/playback-core": "0.22.3",
+        "@mux/mux-video": "0.17.5",
+        "@mux/playback-core": "0.22.4",
         "media-chrome": "~3.1.1"
       }
     },
     "node_modules/@mux/mux-player-react": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@mux/mux-player-react/-/mux-player-react-2.4.0.tgz",
-      "integrity": "sha512-N0zHfNYXo9eNHLlYcHydLDFHk8TQpt4Psi2MyjIn7o8IR2dDsTHNxF5nxVTAMtCx7owohePgXa8g5nvXMixORQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@mux/mux-player-react/-/mux-player-react-2.4.1.tgz",
+      "integrity": "sha512-grM6T847fKnzlK786NG1AxhNS+6A78pEPc5zG4yYvKe3ayGNTOpq/Hnm9pDVkOx5/uMI/yCdSsfiNyytYaw8qA==",
       "dependencies": {
-        "@mux/mux-player": "2.4.0",
-        "@mux/playback-core": "0.22.3",
+        "@mux/mux-player": "2.4.1",
+        "@mux/playback-core": "0.22.4",
         "prop-types": "^15.7.2"
       },
       "peerDependencies": {
@@ -1909,22 +1647,22 @@
       }
     },
     "node_modules/@mux/mux-video": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@mux/mux-video/-/mux-video-0.17.4.tgz",
-      "integrity": "sha512-ePTL+Kxtw03OmCQ6y34A8tTdK4ctsHPzuOY7etCFldhdAMTomwxSacdNwa8BpZ23umkXHp+FQXPyJQIfv4G++Q==",
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/@mux/mux-video/-/mux-video-0.17.5.tgz",
+      "integrity": "sha512-EMLflDnr/o7XQiWKfwnq9BJmj30kpSszzXwpXE4hmBIgc9JAuF3Hl94qv1kyWQAUhrO5hnnOxwGHgv0FvkJ1GQ==",
       "dependencies": {
-        "@mux/playback-core": "0.22.3",
+        "@mux/playback-core": "0.22.4",
         "castable-video": "~1.0.6",
         "custom-media-element": "~1.2.3",
         "media-tracks": "~0.3.0"
       }
     },
     "node_modules/@mux/mux-video-react": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@mux/mux-video-react/-/mux-video-react-0.8.4.tgz",
-      "integrity": "sha512-XzvHL9pVJ/R/xr/5ev/45kOQWLNmBY4bT0MWtUTg92LNMoZ9Nw/QZQSH/suLH/grLgcUNMJTh24M0BWhhrIJlg==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@mux/mux-video-react/-/mux-video-react-0.8.5.tgz",
+      "integrity": "sha512-DNlX+7cExOGoXdPAHMfuqc1u2RjHgUjO9Y4WoPfOQAFH2QqP7Kjd9t0PpKAARES8tWNuWhxjyw+as1gen4OalQ==",
       "dependencies": {
-        "@mux/playback-core": "0.22.3",
+        "@mux/playback-core": "0.22.4",
         "prop-types": "^15.7.2"
       },
       "peerDependencies": {
@@ -1942,9 +1680,9 @@
       }
     },
     "node_modules/@mux/playback-core": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/@mux/playback-core/-/playback-core-0.22.3.tgz",
-      "integrity": "sha512-IZBMMhUKsEtSrxb8XyhfJVzI9g6Ca0poCDrJQy9hCV3+DmgfFPDLSxZZvtSglH5CsmFPHL+hOFD/qn9ewCmAOA==",
+      "version": "0.22.4",
+      "resolved": "https://registry.npmjs.org/@mux/playback-core/-/playback-core-0.22.4.tgz",
+      "integrity": "sha512-f/jWcYbFRjXjdFRNq3MK79D1YHTqvwcfchRLYukE384P3cb027dru+bSxMKESrfkhAhnWFy7fdq/llawl7SU9g==",
       "dependencies": {
         "hls.js": "~1.4.13",
         "mux-embed": "~4.30.0"
@@ -2129,604 +1867,638 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.15.tgz",
-      "integrity": "sha512-JkS36PIS3/UCbq/MaozzV7jECeL+BTt4R75bwY8i+4RASys4xOyUS1HsRyUNSqUXFP4QyCz5aNnh3ltuaxv+pw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.2.0.tgz",
+      "integrity": "sha512-wRlta7GuLWpTqtFfGo+nZyOO1vEvewdNR1R4rTxpC8XU6vG/NDyrFBhwLZsqg1NUoR1noVaXJPC/7ZK47QCySw==",
       "dependencies": {
-        "@smithy/types": "^2.7.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/chunked-blob-reader": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-2.0.0.tgz",
-      "integrity": "sha512-k+J4GHJsMSAIQPChGBrjEmGS+WbPonCXesoqP9fynIqjn7rdOThdH8FAeCmokP9mxTYKQAKoHCLPzNlm6gh7Wg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-2.2.0.tgz",
+      "integrity": "sha512-3GJNvRwXBGdkDZZOGiziVYzDpn4j6zfyULHMDKAGIUo72yHALpE9CbhfQp/XcLNVoc1byfMpn6uW5H2BqPjgaQ==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/chunked-blob-reader-native": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-2.0.1.tgz",
-      "integrity": "sha512-N2oCZRglhWKm7iMBu7S6wDzXirjAofi7tAd26cxmgibRYOBS4D3hGfmkwCpHdASZzwZDD8rluh0Rcqw1JeZDRw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-2.2.0.tgz",
+      "integrity": "sha512-VNB5+1oCgX3Fzs072yuRsUoC2N4Zg/LJ11DTxX3+Qu+Paa6AmbIF0E9sc2wthz9Psrk/zcOlTCyuposlIhPjZQ==",
       "dependencies": {
-        "@smithy/util-base64": "^2.0.1",
-        "tslib": "^2.5.0"
+        "@smithy/util-base64": "^2.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "2.0.21",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.21.tgz",
-      "integrity": "sha512-rlLIGT+BeqjnA6C2FWumPRJS1UW07iU5ZxDHtFuyam4W65gIaOFMjkB90ofKCIh+0mLVQrQFrl/VLtQT/6FWTA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.2.0.tgz",
+      "integrity": "sha512-fsiMgd8toyUba6n1WRmr+qACzXltpdDkPTAaDqc8QqPBUzO+/JKwL6bUBseHVi8tu9l+3JOK+tSf7cay+4B3LA==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.8",
-        "@smithy/types": "^2.7.0",
-        "@smithy/util-config-provider": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.8",
-        "tslib": "^2.5.0"
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-config-provider": "^2.3.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.4.1.tgz",
+      "integrity": "sha512-jCnbEQHvTOUQXxXOS110FIMc83dCXUlrqiG/q0QzUSYhglDj9bJVPFjXmxc6qUfARe0mEb8h9LeVoh7FUYHuUg==",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^2.5.0",
+        "@smithy/middleware-retry": "^2.3.0",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.1.4.tgz",
-      "integrity": "sha512-cwPJN1fa1YOQzhBlTXRavABEYRRchci1X79QRwzaNLySnIMJfztyv1Zkst0iZPLMnpn8+CnHu3wOHS11J5Dr3A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.3.0.tgz",
+      "integrity": "sha512-BWB9mIukO1wjEOo1Ojgl6LrG4avcaC7T/ZP6ptmAaW4xluhSIPZhY+/PI5YKzlk+jsm+4sQZB45Bt1OfMeQa3w==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.8",
-        "@smithy/property-provider": "^2.0.16",
-        "@smithy/types": "^2.7.0",
-        "@smithy/url-parser": "^2.0.15",
-        "tslib": "^2.5.0"
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.15.tgz",
-      "integrity": "sha512-crjvz3j1gGPwA0us6cwS7+5gAn35CTmqu/oIxVbYJo2Qm/sGAye6zGJnMDk3BKhWZw5kcU1G4MxciTkuBpOZPg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.2.0.tgz",
+      "integrity": "sha512-8janZoJw85nJmQZc4L8TuePp2pk1nxLgkxIR0TUjKJ5Dkj5oelB9WtiSSGXCQvNsJl0VSTvK/2ueMXxvpa9GVw==",
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
-        "@smithy/types": "^2.7.0",
-        "@smithy/util-hex-encoding": "^2.0.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-hex-encoding": "^2.2.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-2.0.14.tgz",
-      "integrity": "sha512-41wmYE9smDGJi1ZXp+LogH6BR7MkSsQD91wneIFISF/mupKULvoOJUkv/Nf0NMRxWlM3Bf1Vvi9FlR2oV4KU8Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-2.2.0.tgz",
+      "integrity": "sha512-UaPf8jKbcP71BGiO0CdeLmlg+RhWnlN8ipsMSdwvqBFigl5nil3rHOI/5GE3tfiuX8LvY5Z9N0meuU7Rab7jWw==",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^2.0.14",
-        "@smithy/types": "^2.6.0",
-        "tslib": "^2.5.0"
+        "@smithy/eventstream-serde-universal": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-2.0.14.tgz",
-      "integrity": "sha512-43IyRIzQ82s+5X+t/3Ood00CcWtAXQdmUIUKMed2Qg9REPk8SVIHhpm3rwewLwg+3G2Nh8NOxXlEQu6DsPUcMw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-2.2.0.tgz",
+      "integrity": "sha512-RHhbTw/JW3+r8QQH7PrganjNCiuiEZmpi6fYUAetFfPLfZ6EkiA08uN3EFfcyKubXQxOwTeJRZSQmDDCdUshaA==",
       "dependencies": {
-        "@smithy/types": "^2.6.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/eventstream-serde-node": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-2.0.14.tgz",
-      "integrity": "sha512-jVh9E2qAr6DxH5tWfCAl9HV6tI0pEQ3JVmu85JknDvYTC66djcjDdhctPV2EHuKWf2kjRiFJcMIn0eercW4THA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-2.2.0.tgz",
+      "integrity": "sha512-zpQMtJVqCUMn+pCSFcl9K/RPNtQE0NuMh8sKpCdEHafhwRsjP50Oq/4kMmvxSRy6d8Jslqd8BLvDngrUtmN9iA==",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^2.0.14",
-        "@smithy/types": "^2.6.0",
-        "tslib": "^2.5.0"
+        "@smithy/eventstream-serde-universal": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-2.0.14.tgz",
-      "integrity": "sha512-Ie35+AISNn1NmEjn5b2SchIE49pvKp4Q74bE9ME5RULWI1MgXyGkQUajWd5E6OBSr/sqGcs+rD3IjPErXnCm9g==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-2.2.0.tgz",
+      "integrity": "sha512-pvoe/vvJY0mOpuF84BEtyZoYfbehiFj8KKWk1ds2AT0mTLYFVs+7sBJZmioOFdBXKd48lfrx1vumdPdmGlCLxA==",
       "dependencies": {
-        "@smithy/eventstream-codec": "^2.0.14",
-        "@smithy/types": "^2.6.0",
-        "tslib": "^2.5.0"
+        "@smithy/eventstream-codec": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.3.1.tgz",
-      "integrity": "sha512-6MNk16fqb8EwcYY8O8WxB3ArFkLZ2XppsSNo1h7SQcFdDDwIumiJeO6wRzm7iB68xvsOQzsdQKbdtTieS3hfSQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.5.0.tgz",
+      "integrity": "sha512-BOWEBeppWhLn/no/JxUL/ghTfANTjT7kg3Ww2rPqTUY9R4yHPXxJ9JhMe3Z03LN3aPwiwlpDIUcVw1xDyHqEhw==",
       "dependencies": {
-        "@smithy/protocol-http": "^3.0.11",
-        "@smithy/querystring-builder": "^2.0.15",
-        "@smithy/types": "^2.7.0",
-        "@smithy/util-base64": "^2.0.1",
-        "tslib": "^2.5.0"
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/querystring-builder": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-base64": "^2.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/hash-blob-browser": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-2.0.15.tgz",
-      "integrity": "sha512-HX/7GIyPUT/HDWVYe2HYQu0iRnSYpF4uZVNhAhZsObPRawk5Mv0PbyluBgIFI2DDCCKgL/tloCYYwycff1GtQg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-2.2.0.tgz",
+      "integrity": "sha512-SGPoVH8mdXBqrkVCJ1Hd1X7vh1zDXojNN1yZyZTZsCno99hVue9+IYzWDjq/EQDDXxmITB0gBmuyPh8oAZSTcg==",
       "dependencies": {
-        "@smithy/chunked-blob-reader": "^2.0.0",
-        "@smithy/chunked-blob-reader-native": "^2.0.1",
-        "@smithy/types": "^2.6.0",
-        "tslib": "^2.5.0"
+        "@smithy/chunked-blob-reader": "^2.2.0",
+        "@smithy/chunked-blob-reader-native": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.17.tgz",
-      "integrity": "sha512-Il6WuBcI1nD+e2DM7tTADMf01wEPGK8PAhz4D+YmDUVaoBqlA+CaH2uDJhiySifmuKBZj748IfygXty81znKhw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.2.0.tgz",
+      "integrity": "sha512-zLWaC/5aWpMrHKpoDF6nqpNtBhlAYKF/7+9yMN7GpdR8CzohnWfGtMznPybnwSS8saaXBMxIGwJqR4HmRp6b3g==",
       "dependencies": {
-        "@smithy/types": "^2.7.0",
-        "@smithy/util-buffer-from": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.2",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/hash-stream-node": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-2.0.16.tgz",
-      "integrity": "sha512-4x24GFdeWos1Z49MC5sYdM1j+z32zcUr6oWM9Ggm3WudFAcRIcbG9uDQ1XgJ0Kl+ZTjpqLKniG0iuWvQb2Ud1A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-2.2.0.tgz",
+      "integrity": "sha512-aT+HCATOSRMGpPI7bi7NSsTNVZE/La9IaxLXWoVAYMxHT5hGO3ZOGEMZQg8A6nNL+pdFGtZQtND1eoY084HgHQ==",
       "dependencies": {
-        "@smithy/types": "^2.6.0",
-        "@smithy/util-utf8": "^2.0.2",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.15.tgz",
-      "integrity": "sha512-dlEKBFFwVfzA5QroHlBS94NpgYjXhwN/bFfun+7w3rgxNvVy79SK0w05iGc7UAeC5t+D7gBxrzdnD6hreZnDVQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.2.0.tgz",
+      "integrity": "sha512-nEDASdbKFKPXN2O6lOlTgrEEOO9NHIeO+HVvZnkqc8h5U9g3BIhWsvzFo+UcUbliMHvKNPD/zVxDrkP1Sbgp8Q==",
       "dependencies": {
-        "@smithy/types": "^2.7.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
-      "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/md5-js": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-2.0.16.tgz",
-      "integrity": "sha512-YhWt9aKl+EMSNXyUTUo7I01WHf3HcCkPu/Hl2QmTNwrHT49eWaY7hptAMaERZuHFH0V5xHgPKgKZo2I93DFtgQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-2.2.0.tgz",
+      "integrity": "sha512-M26XTtt9IIusVMOWEAhIvFIr9jYj4ISPPGJROqw6vXngO3IYJCnVVSMFn4Tx1rUTG5BiKJNg9u2nxmBiZC5IlQ==",
       "dependencies": {
-        "@smithy/types": "^2.6.0",
-        "@smithy/util-utf8": "^2.0.2",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.17.tgz",
-      "integrity": "sha512-OyadvMcKC7lFXTNBa8/foEv7jOaqshQZkjWS9coEXPRZnNnihU/Ls+8ZuJwGNCOrN2WxXZFmDWhegbnM4vak8w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.2.0.tgz",
+      "integrity": "sha512-5bl2LG1Ah/7E5cMSC+q+h3IpVHMeOkG0yLRyQT1p2aMJkSrZG7RlXHPuAgb7EyaFeidKEnnd/fNaLLaKlHGzDQ==",
       "dependencies": {
-        "@smithy/protocol-http": "^3.0.11",
-        "@smithy/types": "^2.7.0",
-        "tslib": "^2.5.0"
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.2.3.tgz",
-      "integrity": "sha512-nYfxuq0S/xoAjdLbyn1ixeVB6cyH9wYCMtbbOCpcCRYR5u2mMtqUtVjjPAZ/DIdlK3qe0tpB0Q76szFGNuz+kQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.5.0.tgz",
+      "integrity": "sha512-OBhI9ZEAG8Xen0xsFJwwNOt44WE2CWkfYIxTognC8x42Lfsdf0VN/wCMqpdkySMDio/vts10BiovAxQp0T0faA==",
       "dependencies": {
-        "@smithy/middleware-serde": "^2.0.15",
-        "@smithy/node-config-provider": "^2.1.8",
-        "@smithy/shared-ini-file-loader": "^2.2.7",
-        "@smithy/types": "^2.7.0",
-        "@smithy/url-parser": "^2.0.15",
-        "@smithy/util-middleware": "^2.0.8",
-        "tslib": "^2.5.0"
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "2.0.24",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.24.tgz",
-      "integrity": "sha512-q2SvHTYu96N7lYrn3VSuX3vRpxXHR/Cig6MJpGWxd0BWodUQUWlKvXpWQZA+lTaFJU7tUvpKhRd4p4MU3PbeJg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.3.0.tgz",
+      "integrity": "sha512-5H7kD0My2RkZryvYIWA4C9w6t/pdJfbgEdq+fcZhbnZsqHm/4vYFVjDsOzb5pC7PEpksuijoM9fGbM6eN4rLSg==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.8",
-        "@smithy/protocol-http": "^3.0.11",
-        "@smithy/service-error-classification": "^2.0.8",
-        "@smithy/smithy-client": "^2.1.18",
-        "@smithy/types": "^2.7.0",
-        "@smithy/util-middleware": "^2.0.8",
-        "@smithy/util-retry": "^2.0.8",
-        "tslib": "^2.5.0",
-        "uuid": "^8.3.2"
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/service-error-classification": "^2.1.5",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.15.tgz",
-      "integrity": "sha512-FOZRFk/zN4AT4wzGuBY+39XWe+ZnCFd0gZtyw3f9Okn2CJPixl9GyWe98TIaljeZdqWkgrzGyPre20AcW2UMHQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.3.0.tgz",
+      "integrity": "sha512-sIADe7ojwqTyvEQBe1nc/GXB9wdHhi9UwyX0lTyttmUWDJLP655ZYE1WngnNyXREme8I27KCaUhyhZWRXL0q7Q==",
       "dependencies": {
-        "@smithy/types": "^2.7.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.9.tgz",
-      "integrity": "sha512-bCB5dUtGQ5wh7QNL2ELxmDc6g7ih7jWU3Kx6MYH1h4mZbv9xL3WyhKHojRltThCB1arLPyTUFDi+x6fB/oabtA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.2.0.tgz",
+      "integrity": "sha512-Qntc3jrtwwrsAC+X8wms8zhrTr0sFXnyEGhZd9sLtsJ/6gGQKFzNB+wWbOcpJd7BR8ThNCoKt76BuQahfMvpeA==",
       "dependencies": {
-        "@smithy/types": "^2.7.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.1.8.tgz",
-      "integrity": "sha512-+w26OKakaBUGp+UG+dxYZtFb5fs3tgHg3/QrRrmUZj+rl3cIuw840vFUXX35cVPTUCQIiTqmz7CpVF7+hdINdQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.3.0.tgz",
+      "integrity": "sha512-0elK5/03a1JPWMDPaS726Iw6LpQg80gFut1tNpPfxFuChEEklo2yL823V94SpTZTxmKlXFtFgsP55uh3dErnIg==",
       "dependencies": {
-        "@smithy/property-provider": "^2.0.16",
-        "@smithy/shared-ini-file-loader": "^2.2.7",
-        "@smithy/types": "^2.7.0",
-        "tslib": "^2.5.0"
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.2.1.tgz",
-      "integrity": "sha512-8iAKQrC8+VFHPAT8pg4/j6hlsTQh+NKOWlctJBrYtQa4ExcxX7aSg3vdQ2XLoYwJotFUurg/NLqFCmZaPRrogw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.5.0.tgz",
+      "integrity": "sha512-mVGyPBzkkGQsPoxQUbxlEfRjrj6FPyA3u3u2VXGr9hT8wilsoQdZdvKpMBFMB8Crfhv5dNkKHIW0Yyuc7eABqA==",
       "dependencies": {
-        "@smithy/abort-controller": "^2.0.15",
-        "@smithy/protocol-http": "^3.0.11",
-        "@smithy/querystring-builder": "^2.0.15",
-        "@smithy/types": "^2.7.0",
-        "tslib": "^2.5.0"
+        "@smithy/abort-controller": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/querystring-builder": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.16.tgz",
-      "integrity": "sha512-28Ky0LlOqtEjwg5CdHmwwaDRHcTWfPRzkT6HrhwOSRS2RryAvuDfJrZpM+BMcrdeCyEg1mbcgIMoqTla+rdL8Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+      "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
       "dependencies": {
-        "@smithy/types": "^2.7.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.11.tgz",
-      "integrity": "sha512-3ziB8fHuXIRamV/akp/sqiWmNPR6X+9SB8Xxnozzj+Nq7hSpyKdFHd1FLpBkgfGFUTzzcBJQlDZPSyxzmdcx5A==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.3.0.tgz",
+      "integrity": "sha512-Xy5XK1AFWW2nlY/biWZXu6/krgbaf2dg0q492D8M5qthsnU2H+UgFeZLbM76FnH7s6RO/xhQRkj+T6KBO3JzgQ==",
       "dependencies": {
-        "@smithy/types": "^2.7.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.15.tgz",
-      "integrity": "sha512-e1q85aT6HutvouOdN+dMsN0jcdshp50PSCvxDvo6aIM57LqeXimjfONUEgfqQ4IFpYWAtVixptyIRE5frMp/2A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.2.0.tgz",
+      "integrity": "sha512-L1kSeviUWL+emq3CUVSgdogoM/D9QMFaqxL/dd0X7PCNWmPXqt+ExtrBjqT0V7HLN03Vs9SuiLrG3zy3JGnE5A==",
       "dependencies": {
-        "@smithy/types": "^2.7.0",
-        "@smithy/util-uri-escape": "^2.0.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-uri-escape": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.15.tgz",
-      "integrity": "sha512-jbBvoK3cc81Cj1c1TH1qMYxNQKHrYQ2DoTntN9FBbtUWcGhc+T4FP6kCKYwRLXyU4AajwGIZstvNAmIEgUUNTQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.2.0.tgz",
+      "integrity": "sha512-BvHCDrKfbG5Yhbpj4vsbuPV2GgcpHiAkLeIlcA1LtfpMz3jrqizP1+OguSNSj1MwBHEiN+jwNisXLGdajGDQJA==",
       "dependencies": {
-        "@smithy/types": "^2.7.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.8.tgz",
-      "integrity": "sha512-jCw9+005im8tsfYvwwSc4TTvd29kXRFkH9peQBg5R/4DD03ieGm6v6Hpv9nIAh98GwgYg1KrztcINC1s4o7/hg==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.5.tgz",
+      "integrity": "sha512-uBDTIBBEdAQryvHdc5W8sS5YX7RQzF683XrHePVdFmAgKiMofU15FLSM0/HU03hKTnazdNRFa0YHS7+ArwoUSQ==",
       "dependencies": {
-        "@smithy/types": "^2.7.0"
+        "@smithy/types": "^2.12.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.2.7.tgz",
-      "integrity": "sha512-0Qt5CuiogIuvQIfK+be7oVHcPsayLgfLJGkPlbgdbl0lD28nUKu4p11L+UG3SAEsqc9UsazO+nErPXw7+IgDpQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.4.0.tgz",
+      "integrity": "sha512-WyujUJL8e1B6Z4PBfAqC/aGY1+C7T0w20Gih3yrvJSk97gpiVfB+y7c46T4Nunk+ZngLq0rOIdeVeIklk0R3OA==",
       "dependencies": {
-        "@smithy/types": "^2.7.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.18.tgz",
-      "integrity": "sha512-SJRAj9jT/l9ocm8D0GojMbnA1sp7I4JeStOQ4lEXI8A5eHE73vbjlzlqIFB7cLvIgau0oUl4cGVpF9IGCrvjlw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.2.0.tgz",
+      "integrity": "sha512-+B5TNzj/fRZzVW3z8UUJOkNx15+4E0CLuvJmJUA1JUIZFp3rdJ/M2H5r2SqltaVPXL0oIxv/6YK92T9TsFGbFg==",
       "dependencies": {
-        "@smithy/eventstream-codec": "^2.0.15",
-        "@smithy/is-array-buffer": "^2.0.0",
-        "@smithy/types": "^2.7.0",
-        "@smithy/util-hex-encoding": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.8",
-        "@smithy/util-uri-escape": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.2",
-        "tslib": "^2.5.0"
+        "@smithy/eventstream-codec": "^2.2.0",
+        "@smithy/is-array-buffer": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-hex-encoding": "^2.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-uri-escape": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "2.1.18",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.18.tgz",
-      "integrity": "sha512-7FqdbaJiVaHJDD9IfDhmzhSDbpjyx+ZsfdYuOpDJF09rl8qlIAIlZNoSaflKrQ3cEXZN2YxGPaNWGhbYimyIRQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.5.0.tgz",
+      "integrity": "sha512-DDXWHWdimtS3y/Kw1Jo46KQ0ZYsDKcldFynQERUGBPDpkW1lXOTHy491ALHjwfiBQvzsVKVxl5+ocXNIgJuX4g==",
       "dependencies": {
-        "@smithy/middleware-stack": "^2.0.9",
-        "@smithy/types": "^2.7.0",
-        "@smithy/util-stream": "^2.0.23",
-        "tslib": "^2.5.0"
+        "@smithy/middleware-endpoint": "^2.5.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-stream": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/types": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.7.0.tgz",
-      "integrity": "sha512-1OIFyhK+vOkMbu4aN2HZz/MomREkrAC/HqY5mlJMUJfGrPRwijJDTeiN8Rnj9zUaB8ogXAfIOtZrrgqZ4w7Wnw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.15.tgz",
-      "integrity": "sha512-sADUncUj9rNbOTrdDGm4EXlUs0eQ9dyEo+V74PJoULY4jSQxS+9gwEgsPYyiu8PUOv16JC/MpHonOgqP/IEDZA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.2.0.tgz",
+      "integrity": "sha512-hoA4zm61q1mNTpksiSWp2nEl1dt3j726HdRhiNgVJQMj7mLp7dprtF57mOB6JvEk/x9d2bsuL5hlqZbBuHQylQ==",
       "dependencies": {
-        "@smithy/querystring-parser": "^2.0.15",
-        "@smithy/types": "^2.7.0",
-        "tslib": "^2.5.0"
+        "@smithy/querystring-parser": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/util-base64": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.1.tgz",
-      "integrity": "sha512-DlI6XFYDMsIVN+GH9JtcRp3j02JEVuWIn/QOZisVzpIAprdsxGveFed0bjbMRCqmIFe8uetn5rxzNrBtIGrPIQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.3.0.tgz",
+      "integrity": "sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==",
       "dependencies": {
-        "@smithy/util-buffer-from": "^2.0.0",
-        "tslib": "^2.5.0"
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-body-length-browser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.1.tgz",
-      "integrity": "sha512-NXYp3ttgUlwkaug4bjBzJ5+yIbUbUx8VsSLuHZROQpoik+gRkIBeEG9MPVYfvPNpuXb/puqodeeUXcKFe7BLOQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.2.0.tgz",
+      "integrity": "sha512-dtpw9uQP7W+n3vOtx0CfBD5EWd7EPdIdsQnWTDoFf77e3VUf05uA7R7TGipIo8e4WL2kuPdnsr3hMQn9ziYj5w==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/util-body-length-node": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz",
-      "integrity": "sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.3.0.tgz",
+      "integrity": "sha512-ITWT1Wqjubf2CJthb0BuT9+bpzBfXeMokH/AAa5EJQgbv9aPMVfnM76iFIZVFf50hYXGbtiV71BHAthNWd6+dw==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
-      "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
       "dependencies": {
-        "@smithy/is-array-buffer": "^2.0.0",
-        "tslib": "^2.5.0"
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-config-provider": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz",
-      "integrity": "sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.3.0.tgz",
+      "integrity": "sha512-HZkzrRcuFN1k70RLqlNK4FnPXKOpkik1+4JaBoHNJn+RnJGYqaa3c5/+XtLOXhlKzlRgNvyaLieHTW2VwGN0VQ==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "2.0.22",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.22.tgz",
-      "integrity": "sha512-qcF20IHHH96FlktvBRICDXDhLPtpVmtksHmqNGtotb9B0DYWXsC6jWXrkhrrwF7tH26nj+npVTqh9isiFV1gdA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.2.0.tgz",
+      "integrity": "sha512-2okTdZaCBvOJszAPU/KSvlimMe35zLOKbQpHhamFJmR7t95HSe0K3C92jQPjKY3PmDBD+7iMkOnuW05F5OlF4g==",
       "dependencies": {
-        "@smithy/property-provider": "^2.0.16",
-        "@smithy/smithy-client": "^2.1.18",
-        "@smithy/types": "^2.7.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "2.0.29",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.29.tgz",
-      "integrity": "sha512-+uG/15VoUh6JV2fdY9CM++vnSuMQ1VKZ6BdnkUM7R++C/vLjnlg+ToiSR1FqKZbMmKBXmsr8c/TsDWMAYvxbxQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.3.0.tgz",
+      "integrity": "sha512-hfKXnNLmsW9cmLb/JXKIvtuO6Cf4SuqN5PN1C2Ru/TBIws+m1wSgb+A53vo0r66xzB6E82inKG2J7qtwdi+Kkw==",
       "dependencies": {
-        "@smithy/config-resolver": "^2.0.21",
-        "@smithy/credential-provider-imds": "^2.1.4",
-        "@smithy/node-config-provider": "^2.1.8",
-        "@smithy/property-provider": "^2.0.16",
-        "@smithy/smithy-client": "^2.1.18",
-        "@smithy/types": "^2.7.0",
-        "tslib": "^2.5.0"
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/credential-provider-imds": "^2.3.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@smithy/util-hex-encoding": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
-      "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
+    "node_modules/@smithy/util-endpoints": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.2.0.tgz",
+      "integrity": "sha512-BuDHv8zRjsE5zXd3PxFXFknzBG3owCpjq8G3FcsXW3CykYXuEqM3nTSsmLzw5q+T12ZYuDlVUZKBdpNbhVtlrQ==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.2.0.tgz",
+      "integrity": "sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.8.tgz",
-      "integrity": "sha512-qkvqQjM8fRGGA8P2ydWylMhenCDP8VlkPn8kiNuFEaFz9xnUKC2irfqsBSJrfrOB9Qt6pQsI58r3zvvumhFMkw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.2.0.tgz",
+      "integrity": "sha512-L1qpleXf9QD6LwLCJ5jddGkgWyuSvWBkJwWAZ6kFkdifdso+sk3L3O1HdmPvCdnCK3IS4qWyPxev01QMnfHSBw==",
       "dependencies": {
-        "@smithy/types": "^2.7.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.8.tgz",
-      "integrity": "sha512-cQTPnVaVFMjjS6cb44WV2yXtHVyXDC5icKyIbejMarJEApYeJWpBU3LINTxHqp/tyLI+MZOUdosr2mZ3sdziNg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.2.0.tgz",
+      "integrity": "sha512-q9+pAFPTfftHXRytmZ7GzLFFrEGavqapFc06XxzZFcSIGERXMerXxCitjOG1prVDR9QdjqotF40SWvbqcCpf8g==",
       "dependencies": {
-        "@smithy/service-error-classification": "^2.0.8",
-        "@smithy/types": "^2.7.0",
-        "tslib": "^2.5.0"
+        "@smithy/service-error-classification": "^2.1.5",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "2.0.23",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.23.tgz",
-      "integrity": "sha512-OJMWq99LAZJUzUwTk+00plyxX3ESktBaGPhqNIEVab+53gLULiWN9B/8bRABLg0K6R6Xg4t80uRdhk3B/LZqMQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.2.0.tgz",
+      "integrity": "sha512-17faEXbYWIRst1aU9SvPZyMdWmqIrduZjVOqCPMIsWFNxs5yQQgFrJL6b2SdiCzyW9mJoDjFtgi53xx7EH+BXA==",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^2.3.1",
-        "@smithy/node-http-handler": "^2.2.1",
-        "@smithy/types": "^2.7.0",
-        "@smithy/util-base64": "^2.0.1",
-        "@smithy/util-buffer-from": "^2.0.0",
-        "@smithy/util-hex-encoding": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.2",
-        "tslib": "^2.5.0"
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-hex-encoding": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-uri-escape": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
-      "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.2.0.tgz",
+      "integrity": "sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.2.tgz",
-      "integrity": "sha512-qOiVORSPm6Ce4/Yu6hbSgNHABLP2VMv8QOC3tTDNHHlWY19pPyc++fBTbZPtx6egPXi4HQxKDnMxVxpbtX2GoA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
       "dependencies": {
-        "@smithy/util-buffer-from": "^2.0.0",
-        "tslib": "^2.5.0"
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.14.tgz",
-      "integrity": "sha512-Q6gSz4GUNjNGhrfNg+2Mjy+7K4pEI3r82x1b/+3dSc03MQqobMiUrRVN/YK/4nHVagvBELCoXsiHAFQJNQ5BeA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.2.0.tgz",
+      "integrity": "sha512-IHk53BVw6MPMi2Gsn+hCng8rFA3ZmR3Rk7GllxDUW9qFJl/hiSvskn7XldkECapQVkIg/1dHpMAxI9xSTaLLSA==",
       "dependencies": {
-        "@smithy/abort-controller": "^2.0.14",
-        "@smithy/types": "^2.6.0",
-        "tslib": "^2.5.0"
+        "@smithy/abort-controller": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -5204,9 +4976,13 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
         "uuid": "dist/bin/uuid"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "chokidar": "^3.6.0",
         "magicast": "^0.3.3",
         "symlink-dir": "^5.2.1",
-        "undici": "^6.11.1",
+        "undici": "^5.28.4",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -4205,11 +4205,14 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.11.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.11.1.tgz",
-      "integrity": "sha512-KyhzaLJnV1qa3BSHdj4AZ2ndqI0QWPxYzaIOio0WzcEJB9gvuysprJSLtpvc2D9mhR9jPDUk7xlJlZbH2KR5iw==",
+      "version": "5.28.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
       "engines": {
-        "node": ">=18.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -72,33 +72,33 @@
     }
   },
   "devDependencies": {
-    "@types/dotenv-flow": "^3.3.1",
-    "@types/node": "^20.8.4",
-    "@types/react": "^18.2.27",
-    "@types/yargs": "^17.0.28",
+    "@types/dotenv-flow": "^3.3.3",
+    "@types/node": "^20.12.3",
+    "@types/react": "18.2.42",
+    "@types/yargs": "^17.0.32",
     "c8": "^9.1.0",
     "esbuild": "^0.20.2",
     "glob": "^10.3.12",
     "next": "^14.1.4",
     "react": "^18.2.0",
     "react-test-renderer": "^18.2.0",
-    "tsx": "^3.13.0",
-    "typescript": "^5.2.2"
+    "tsx": "3.13.0",
+    "typescript": "^5.4.3"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "~3.540.0",
-    "@inquirer/prompts": "^3.2.0",
+    "@aws-sdk/client-s3": "^3.540.0",
+    "@inquirer/prompts": "^4.3.1",
     "@mux/mux-node": "8.2.3",
     "@mux/mux-player-react": "2.4.1",
     "@mux/mux-video-react": "^0.8.5",
     "@next/env": "^14.1.4",
     "@paralleldrive/cuid2": "^2.2.2",
     "@vercel/blob": "^0.22.1",
-    "chalk": "^4.1.2",
+    "chalk": "^5.3.0",
     "chokidar": "^3.6.0",
     "magicast": "^0.3.3",
     "symlink-dir": "^5.2.1",
-    "undici": "^5.25.4",
+    "undici": "^6.11.1",
     "yargs": "^17.7.2"
   },
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -86,11 +86,11 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "~3.437.0",
+    "@aws-sdk/client-s3": "~3.540.0",
     "@inquirer/prompts": "^3.2.0",
     "@mux/mux-node": "8.2.3",
-    "@mux/mux-player-react": "2.4.0",
-    "@mux/mux-video-react": "^0.8.4",
+    "@mux/mux-player-react": "2.4.1",
+    "@mux/mux-video-react": "^0.8.5",
     "@next/env": "^14.1.4",
     "@paralleldrive/cuid2": "^2.2.2",
     "@vercel/blob": "^0.22.1",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "chokidar": "^3.6.0",
     "magicast": "^0.3.3",
     "symlink-dir": "^5.2.1",
-    "undici": "^6.11.1",
+    "undici": "^5.28.4",
     "yargs": "^17.7.2"
   },
   "prettier": {


### PR DESCRIPTION
needed a locked version

- @types/react types would not be compatible with Mux elements older React types 
- newer tsx was breaking test coverage
- undici 6 was breaking next.js builds 

I tested the new aws-sdk worked as expected.