### PR TITLE
fix: sizing issue w/ bg video which made the

### DIFF
--- a/examples/default-provider/app/background-video/page.tsx
+++ b/examples/default-provider/app/background-video/page.tsx
@@ -10,7 +10,11 @@ export default function Page() {
   return (
     <>
       <section>
-        <BackgroundVideo src={countryClouds} disableTracking>
+        <BackgroundVideo
+          src={countryClouds}
+          disableTracking
+          style={{ aspectRatio: 1.9 }}
+        >
           <h1>next-video</h1>
           <p>
             A React component for adding video to your Next.js application.

--- a/examples/default-provider/app/globals.css
+++ b/examples/default-provider/app/globals.css
@@ -143,7 +143,7 @@ footer .inner {
 }
 
 .mux-svg {
-  width: 2.2rem;
+  width: 2.5rem;
 }
 
 aside nav ul {

--- a/src/components/players/background-player.tsx
+++ b/src/components/players/background-player.tsx
@@ -87,6 +87,8 @@ export const BackgroundPlayer = forwardRef((allProps: BackgroundPlayerProps, for
         }
 
         .next-video-bg-poster {
+          width: 100%;
+          height: 100%;
           position: relative;
           object-fit: cover;
           pointer-events: none;


### PR DESCRIPTION
blur image not show before either img or video got dimensions via their url sources.

I also got reminded that we can probably get the aspectRatio from the tiny image on the server and store that.
that way the user doesn't need to manually set it.