### PR TITLE
feat: Allow assets to be saved in different locations

### DIFF
--- a/src/assets.ts
+++ b/src/assets.ts
@@ -1,6 +1,6 @@
 import * as path from 'node:path';
 import { cwd } from 'node:process';
-import { stat, readFile, writeFile, mkdir } from 'node:fs/promises';
+import { stat } from 'node:fs/promises';
 import { getVideoConfig } from './config.js';
 import { deepMerge, camelCase, isRemote, toSafePath } from './utils/utils.js';
 import * as transformers from './providers/transformers.js';

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -118,6 +118,7 @@ export async function updateAsset(
 ) {
   const assetConfigPath = await getAssetConfigPath(filePath);
   const currentAsset = await getAsset(filePath);
+  const { saveAsset } = await getVideoConfig();
 
   if (!currentAsset) {
     throw new Error(`Asset not found: ${filePath}`);
@@ -129,7 +130,7 @@ export async function updateAsset(
 
   newAssetDetails = transformAsset(transformers, newAssetDetails);
 
-  await writeFile(assetConfigPath, JSON.stringify(newAssetDetails));
+  await saveAsset(assetConfigPath, JSON.stringify(newAssetDetails));
 
   return newAssetDetails;
 }

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -48,8 +48,7 @@ export interface AssetSource {
 export async function getAsset(filePath: string): Promise<Asset | undefined> {
   const { loadAsset } = await getVideoConfig();
   const assetConfigPath = await getAssetConfigPath(filePath);
-  const jsonAsset = await loadAsset(assetConfigPath);
-  const asset = JSON.parse(jsonAsset);
+  const asset = await loadAsset(assetConfigPath);
   return asset;
 }
 
@@ -107,7 +106,7 @@ export async function createAsset(
     }
   }
 
-  videoConfig.saveAsset(assetConfigPath, JSON.stringify(newAssetDetails));
+  videoConfig.saveAsset(assetConfigPath, newAssetDetails);
 
   return newAssetDetails;
 }
@@ -130,7 +129,7 @@ export async function updateAsset(
 
   newAssetDetails = transformAsset(transformers, newAssetDetails);
 
-  await saveAsset(assetConfigPath, JSON.stringify(newAssetDetails));
+  await saveAsset(assetConfigPath, newAssetDetails);
 
   return newAssetDetails;
 }

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -46,9 +46,10 @@ export interface AssetSource {
 }
 
 export async function getAsset(filePath: string): Promise<Asset | undefined> {
+  const { loadAsset } = await getVideoConfig();
   const assetConfigPath = await getAssetConfigPath(filePath);
-  const file = await readFile(assetConfigPath);
-  const asset = JSON.parse(file.toString());
+  const jsonAsset = await loadAsset(assetConfigPath);
+  const asset = JSON.parse(jsonAsset);
   return asset;
 }
 
@@ -106,18 +107,7 @@ export async function createAsset(
     }
   }
 
-  try {
-    await mkdir(path.dirname(assetConfigPath), { recursive: true });
-    await writeFile(assetConfigPath, JSON.stringify(newAssetDetails), {
-      flag: 'wx',
-    });
-  } catch (err: any) {
-    if (err.code === 'EEXIST') {
-      // The file already exists, and that's ok in this case. Ignore the error.
-      return;
-    }
-    throw err;
-  }
+  videoConfig.saveAsset(assetConfigPath, JSON.stringify(newAssetDetails));
 
   return newAssetDetails;
 }

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -105,18 +105,7 @@ export async function createAsset(
     }
   }
 
-  try {
-    await mkdir(path.dirname(assetConfigPath), { recursive: true });
-    await writeFile(assetConfigPath, JSON.stringify(newAssetDetails), {
-      flag: 'wx',
-    });
-  } catch (err: any) {
-    if (err.code === 'EEXIST') {
-      // The file already exists, and that's ok in this case. Ignore the error.
-      return;
-    }
-    throw err;
-  }
+  await videoConfig.saveAsset(assetConfigPath, newAssetDetails)
 
   return newAssetDetails;
 }
@@ -125,6 +114,7 @@ export async function updateAsset(
   filePath: string,
   assetDetails: Partial<Asset>
 ) {
+  const videoConfig = await getVideoConfig();
   const assetConfigPath = await getAssetConfigPath(filePath);
   const currentAsset = await getAsset(filePath);
 
@@ -138,7 +128,7 @@ export async function updateAsset(
 
   newAssetDetails = transformAsset(transformers, newAssetDetails);
 
-  await writeFile(assetConfigPath, JSON.stringify(newAssetDetails));
+  await videoConfig.updateAsset(assetConfigPath, newAssetDetails)
 
   return newAssetDetails;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ import { stat, readFile, writeFile, mkdir } from 'node:fs/promises';
 import { pathToFileURL } from 'node:url';
 import nextConfig from 'next/config.js';
 import type { NextConfig } from 'next';
+import { Asset } from './assets';
 // @ts-ignore
 const getConfig = nextConfig.default;
 
@@ -27,8 +28,8 @@ export type VideoConfigComplete = {
   /* An optional function to generate the local asset path for remote sources. */
   remoteSourceAssetPath?: (url: string) => string;
 
-  loadAsset: (path: string) => Promise<string>;
-  saveAsset: (path: string, jsonAsset: string) => Promise<void>;
+  loadAsset: (path: string) => Promise<Asset>;
+  saveAsset: (path: string, asset: Asset) => Promise<void>;
 };
 
 export type ProviderConfig = {
@@ -72,10 +73,10 @@ export const videoConfigDefault: VideoConfigComplete = {
     const asset = JSON.parse(file.toString());
     return asset;
   },
-  saveAsset: async (assetPath, jsonAsset) => {
+  saveAsset: async (assetPath, asset) => {
     try {
       await mkdir(path.dirname(assetPath), { recursive: true });
-      await writeFile(assetPath, jsonAsset, {
+      await writeFile(assetPath, JSON.stringify(asset), {
         flag: 'wx',
       });
     } catch (err: any) {

--- a/tests/cli/lib/next-config.test.ts
+++ b/tests/cli/lib/next-config.test.ts
@@ -47,7 +47,6 @@ describe('updateNextConfig', () => {
     await updateNextConfigFile(dirPath);
 
     const updatedContents = await fs.readFile(path.join(dirPath, 'next.config.mjs'), 'utf-8');
-
     assert(updatedContents.includes('next-video'));
   });
 });

--- a/tests/with-next-video.test.ts
+++ b/tests/with-next-video.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert';
 import { describe, it } from 'node:test';
 
 import { withNextVideo } from '../src/with-next-video.js';
+import { Asset } from '../src/assets.js';
 
 describe('withNextVideo', () => {
   it('should handle nextConfig being a function', async () => {
@@ -50,26 +51,24 @@ describe('withNextVideo', () => {
 
   it('should handle videoConfig being passed', async () => {
     const nextConfig = {};
+    const fakeLoadAsset = function (path: string): Promise<Asset | undefined> { return Promise.resolve(undefined) }
 
     const result = await withNextVideo(nextConfig, {
       path: '/api/video-files',
       folder: 'video-files',
       provider: 'vercel-blob',
+      loadAsset: fakeLoadAsset
     });
 
-    const { saveAsset, loadAsset, ...config } = result.serverRuntimeConfig.nextVideo;
-
+    const config = result.serverRuntimeConfig.nextVideo;
     assert.deepEqual(config, {
       path: '/api/video-files',
       folder: 'video-files',
       provider: 'vercel-blob',
-      providerConfig: {}
+      providerConfig: {},
+      loadAsset: fakeLoadAsset
     });
-
-    assert.equal(typeof saveAsset, 'function');
-    assert.equal(typeof loadAsset, 'function');
   });
-
 
   it('should change the webpack config', async () => {
     const nextConfig = {};

--- a/tests/with-next-video.test.ts
+++ b/tests/with-next-video.test.ts
@@ -52,12 +52,16 @@ describe('withNextVideo', () => {
   it('should handle videoConfig being passed', async () => {
     const nextConfig = {};
     const fakeLoadAsset = function (path: string): Promise<Asset | undefined> { return Promise.resolve(undefined) }
+    const fakeSaveAsset = function (path: string, asset: Asset): Promise<void> { return Promise.resolve() }
+    const fakeUpdateAsset = function (path: string, asset: Asset): Promise<void> { return Promise.resolve() }
 
     const result = await withNextVideo(nextConfig, {
       path: '/api/video-files',
       folder: 'video-files',
       provider: 'vercel-blob',
-      loadAsset: fakeLoadAsset
+      loadAsset: fakeLoadAsset,
+      saveAsset: fakeSaveAsset,
+      updateAsset: fakeUpdateAsset
     });
 
     const config = result.serverRuntimeConfig.nextVideo;
@@ -66,7 +70,9 @@ describe('withNextVideo', () => {
       folder: 'video-files',
       provider: 'vercel-blob',
       providerConfig: {},
-      loadAsset: fakeLoadAsset
+      loadAsset: fakeLoadAsset,
+      saveAsset: fakeSaveAsset,
+      updateAsset: fakeUpdateAsset
     });
   });
 

--- a/tests/with-next-video.test.ts
+++ b/tests/with-next-video.test.ts
@@ -57,13 +57,19 @@ describe('withNextVideo', () => {
       provider: 'vercel-blob',
     });
 
-    assert.deepEqual(result.serverRuntimeConfig.nextVideo, {
+    const { saveAsset, loadAsset, ...config } = result.serverRuntimeConfig.nextVideo;
+
+    assert.deepEqual(config, {
       path: '/api/video-files',
       folder: 'video-files',
       provider: 'vercel-blob',
-      providerConfig: {},
+      providerConfig: {}
     });
+
+    assert.equal(typeof saveAsset, 'function');
+    assert.equal(typeof loadAsset, 'function');
   });
+
 
   it('should change the webpack config', async () => {
     const nextConfig = {};


### PR DESCRIPTION
This proposal aims to keep next-video fully backward compatible while allowing assets to be saved to a database or sent to an API.

The idea is to make the asset-saving and uploading functions configurable, so developers can choose where to save them. The default configuration will maintain the current behavior of saving to the filesystem.

This is a draft; there are still some tests to fix, but I would appreciate any early feedback.