### PR TITLE
Next 15 - Fix adding Video JSON to the build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,10 +42,10 @@
         "typescript": "^5.5.2"
       },
       "peerDependencies": {
-        "@types/react": "^17.0.0 || ^17.0.0-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0",
-        "next": ">=12.0.0",
-        "react": "^17.0.2 || ^17.0.0-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0",
-        "react-dom": "^17.0.2 || ^17.0.2-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0"
+        "@types/react": "^19 || ^19.0.0-0",
+        "next": ">=15.0.0",
+        "react": "^19 || ^19.0.0-0",
+        "react-dom": "^19 || ^19.0.0-0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -2974,7 +2974,7 @@
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -2985,7 +2985,7 @@
       "version": "18.3.3",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
       "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -3437,7 +3437,7 @@
     },
     "node_modules/csstype": {
       "version": "3.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/custom-media-element": {
@@ -3509,27 +3509,6 @@
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "license": "MIT"
-    },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
-    "node_modules/encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -4498,23 +4477,12 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-dom": {
-      "version": "18.2.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.0"
-      },
-      "peerDependencies": {
-        "react": "^18.2.0"
       }
     },
     "node_modules/react-is": {
@@ -4661,6 +4629,7 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -60,10 +60,10 @@
     "coverage": "c8 report --reporter=text-lcov > ./coverage/lcov.info"
   },
   "peerDependencies": {
-    "@types/react": "^17.0.0 || ^17.0.0-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0",
-    "next": ">=12.0.0",
-    "react": "^17.0.2 || ^17.0.0-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0",
-    "react-dom": "^17.0.2 || ^17.0.2-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0"
+    "@types/react": "^19 || ^19.0.0-0",
+    "next": ">=15.0.0",
+    "react": "^19 || ^19.0.0-0",
+    "react-dom": "^19 || ^19.0.0-0"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/src/with-next-video.ts
+++ b/src/with-next-video.ts
@@ -40,15 +40,12 @@ export function withNextVideo(nextConfig: any, videoConfig?: VideoConfig) {
     });
   }
 
-  const experimental = { ...nextConfig.experimental };
-
-  experimental.outputFileTracingIncludes = {
-    ...experimental.outputFileTracingIncludes,
+  nextConfig.outputFileTracingIncludes = {
+    ...nextConfig.outputFileTracingIncludes,
     [path]: [`./${folder}/**/*.json`],
   };
 
   return Object.assign({}, nextConfig, {
-    experimental,
     webpack(config: any, options: any) {
       if (!options.defaultLoaders) {
         throw new Error(


### PR DESCRIPTION
`outputFileTracing` is not available anymore in `experimental` but at the root level of the config after https://github.com/vercel/next.js/pull/68464
Note that this change as is would make the library compatible only with Next 15+


Currently users are seeing this at build time

> ⚠ Invalid next.config.js options detected: 
 ⚠     Unrecognized key(s) in object: 'outputFileTracingIncludes' at "experimental"
 ⚠ See more info here: https://nextjs.org/docs/messages/invalid-next-config
 ⚠ `experimental.outputFileTracingIncludes` has been moved to `outputFileTracingIncludes`. Please update your next.config.js file accordingly.