### PR TITLE
Add Cloudinary provider to next-video

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -71,6 +71,14 @@ export type ProviderConfig = {
     /* An optional function to generate the bucket asset key. */
     generateAssetKey?: (filePathOrURL: string, folder: string) => string;
   };
+
+  cloudinary?: {
+    cloudName: string;
+    apiKey: string;
+    apiSecret: string;
+    /* An optional function to generate the public ID for the asset. */
+    generatePublicId?: (filePathOrURL: string, folder: string) => string;
+  };
 };
 
 export type VideoConfig = Partial<VideoConfigComplete>;

--- a/src/providers/cloudinary/provider.ts
+++ b/src/providers/cloudinary/provider.ts
@@ -1,0 +1,129 @@
+import { ReadStream, createReadStream } from 'node:fs';
+import { Readable } from 'node:stream';
+import fs from 'node:fs/promises';
+import { env } from 'node:process';
+import { fetch as uFetch } from 'undici';
+import chalk from 'chalk';
+import { v2 as cloudinary } from 'cloudinary';
+
+import { updateAsset, Asset } from '../../assets.js';
+import { getVideoConfig } from '../../config.js';
+import { isRemote } from '../../utils/utils.js';
+import log from '../../utils/logger.js';
+
+export type CloudinaryMetadata = {
+  publicId?: string;
+  url?: string;
+  secureUrl?: string;
+};
+
+cloudinary.config({
+  cloud_name: env.CLOUDINARY_CLOUD_NAME,
+  api_key: env.CLOUDINARY_API_KEY,
+  api_secret: env.CLOUDINARY_API_SECRET,
+});
+
+export async function uploadLocalFile(asset: Asset) {
+  const filePath = asset.originalFilePath;
+
+  if (!filePath) {
+    log.error('No filePath provided for asset.');
+    console.error(asset);
+    return;
+  }
+
+  // Handle imported remote videos.
+  if (isRemote(filePath)) {
+    return uploadRequestedFile(asset);
+  }
+
+  if (asset.status === 'ready') {
+    return;
+  } else if (asset.status === 'uploading') {
+    // Right now this re-starts the upload from the beginning.
+    // We should probably do something smarter here.
+    log.info(log.label('Resuming upload:'), filePath);
+  }
+
+  await updateAsset(filePath, {
+    status: 'uploading',
+  });
+
+  const fileStats = await fs.stat(filePath);
+  const stream = createReadStream(filePath);
+
+  return putAsset(filePath, fileStats.size, stream);
+}
+
+export async function uploadRequestedFile(asset: Asset) {
+  const filePath = asset.originalFilePath;
+
+  if (!filePath) {
+    log.error('No URL provided for asset.');
+    console.error(asset);
+    return;
+  }
+
+  if (asset.status === 'ready') {
+    return;
+  }
+
+  await updateAsset(filePath, {
+    status: 'uploading',
+  });
+
+  const response = await uFetch(filePath);
+  const size = Number(response.headers.get('content-length'));
+  const stream = response.body;
+
+  if (!stream) {
+    log.error('Error fetching the requested file:', filePath);
+    return;
+  }
+
+  return putAsset(filePath, size, Readable.fromWeb(stream));
+}
+
+async function putAsset(filePath: string, size: number, stream: ReadStream | Readable) {
+  log.info(log.label('Uploading file:'), `${filePath} (${size} bytes)`);
+
+  let result;
+  try {
+    result = await cloudinary.uploader.upload_stream(
+      { resource_type: 'video' },
+      (error, result) => {
+        if (error) {
+          log.error('Error uploading to Cloudinary');
+          console.error(error);
+          return;
+        }
+
+        log.success(log.label('File uploaded:'), `${filePath} (${size} bytes)`);
+        log.space(chalk.gray('>'), log.label('URL:'), result.secure_url);
+
+        updateAsset(filePath, {
+          status: 'ready',
+          providerMetadata: {
+            cloudinary: {
+              publicId: result.public_id,
+              url: result.url,
+              secureUrl: result.secure_url,
+            } as CloudinaryMetadata,
+          },
+        });
+      }
+    );
+
+    stream.pipe(result);
+  } catch (e) {
+    log.error('Error uploading to Cloudinary');
+    console.error(e);
+    return;
+  }
+
+  if (stream instanceof ReadStream) {
+    stream.close();
+  }
+
+  return;
+}

--- a/src/providers/cloudinary/transformer.ts
+++ b/src/providers/cloudinary/transformer.ts
@@ -1,0 +1,14 @@
+import type { Asset, AssetSource } from '../../assets.js';
+
+export function transform(asset: Asset) {
+  const providerMetadata = asset.providerMetadata?.cloudinary;
+  if (!providerMetadata) return asset;
+
+  const source: AssetSource = { src: providerMetadata.secureUrl };
+
+  return {
+    ...asset,
+    sources: [source],
+    poster: `${providerMetadata.secureUrl}.jpg`,
+  };
+}

--- a/src/providers/providers.ts
+++ b/src/providers/providers.ts
@@ -2,4 +2,5 @@ export * as mux from './mux/provider.js';
 export * as vercelBlob from './vercel-blob/provider.js';
 export * as backblaze from './backblaze/provider.js';
 export * as amazonS3 from './amazon-s3/provider.js';
-export * as cloudflareR2 from './cloudflare-r2/provider.js'
+export * as cloudflareR2 from './cloudflare-r2/provider.js';
+export * as cloudinary from './cloudinary/provider.js';


### PR DESCRIPTION
Add Cloudinary provider to the set of available providers in next-video.
fix https://github.com/muxinc/next-video/issues/223

* **Add Cloudinary provider**: Add `cloudinary` to the list of exported providers in `src/providers/providers.ts`.
* **Implement Cloudinary upload logic**: Create `src/providers/cloudinary/provider.ts` with functions `uploadLocalFile` and `uploadRequestedFile` to handle local and remote file uploads using Cloudinary API.
* **Implement Cloudinary asset transformation**: Create `src/providers/cloudinary/transformer.ts` with a `transform` function to generate Cloudinary URLs for video sources and posters.
* **Update configuration**: Modify `src/config.ts` to include Cloudinary provider configuration options.

