### PR TITLE
Removed unused Webpack config for sharp

### DIFF
--- a/src/with-next-video.ts
+++ b/src/with-next-video.ts
@@ -84,20 +84,6 @@ export function withNextVideo(nextConfig: any, videoConfig?: VideoConfig) {
         );
       }
 
-      if (Array.isArray(config.externals)) {
-        config.externals.unshift({
-          sharp: 'commonjs sharp',
-        });
-      } else {
-        config.externals = Object.assign(
-          {},
-          {
-            sharp: 'commonjs sharp',
-          },
-          config.externals
-        );
-      }
-
       config.infrastructureLogging = {
         ...config.infrastructureLogging,
         // Silence warning about dynamic import of next.config file.

--- a/tests/with-next-video.test.ts
+++ b/tests/with-next-video.test.ts
@@ -92,7 +92,6 @@ describe('withNextVideo', () => {
     };
     const webpackConfig = result.webpack(config, options);
 
-    assert.equal(webpackConfig.externals[0].sharp, 'commonjs sharp');
     assert.equal(webpackConfig.module.rules.length, 2);
     assert.deepEqual(webpackConfig.infrastructureLogging, { level: 'error' });
   });


### PR DESCRIPTION
If I understand the history of this repo correctly, Sharp is no longer used. This config to list Sharp as an external can introduce errors when next-video is used by a site that already uses Sharp.