### PR TITLE
feat: handle missing token errors

### DIFF
--- a/src/cli/sync.ts
+++ b/src/cli/sync.ts
@@ -152,7 +152,7 @@ export async function handler(argv: Arguments) {
       return;
     }
     if(err.message.includes("MUX_TOKEN_ID environment variable is missing or empty") || err.message.includes("MUX_TOKEN_SECRET environment variable is missing or empty")){
-      log.error(`${err.message} Visit \x1b[4;34mhttps://next-video.dev/docs#remote-storage-and-optimization\x1b[0m for more information.`);
+      log.error(`Mux MUX_TOKEN_ID or MUX_TOKEN_SECRET can't be found. Visit \x1b[4;34mhttps://next-video.dev/docs#remote-storage-and-optimization\x1b[0m for more information.`);
       return;
     }    
 

--- a/src/cli/sync.ts
+++ b/src/cli/sync.ts
@@ -152,7 +152,7 @@ export async function handler(argv: Arguments) {
       return;
     }
     if(err.message.includes("MUX_TOKEN_ID environment variable is missing or empty") || err.message.includes("MUX_TOKEN_SECRET environment variable is missing or empty")){
-      log.error(err.message);
+      log.error(err.message, "Visit https://github.com/muxinc/next-video?tab=readme-ov-file#remote-storage-and-optimization for more information.");
       return;
     }
 

--- a/src/cli/sync.ts
+++ b/src/cli/sync.ts
@@ -152,7 +152,7 @@ export async function handler(argv: Arguments) {
       return;
     }
     if(err.message.includes("MUX_TOKEN_ID environment variable is missing or empty") || err.message.includes("MUX_TOKEN_SECRET environment variable is missing or empty")){
-      log.error(`${err.message} \x1b[4;34mVisit https://next-video.dev/docs#remote-storage-and-optimization\x1b[0m for more information.`);
+      log.error(`${err.message} Visit \x1b[4;34mhttps://next-video.dev/docs#remote-storage-and-optimization\x1b[0m for more information.`);
       return;
     }    
 

--- a/src/cli/sync.ts
+++ b/src/cli/sync.ts
@@ -151,6 +151,10 @@ export async function handler(argv: Arguments) {
       log.warning(`Source video file does not exist: ${err.path}`);
       return;
     }
+    if(err.message.includes("MUX_TOKEN_ID environment variable is missing or empty") || err.message.includes("MUX_TOKEN_SECRET environment variable is missing or empty")){
+      log.error(err.message);
+      return;
+    }
 
     log.error('An unknown error occurred', err);
   }

--- a/src/cli/sync.ts
+++ b/src/cli/sync.ts
@@ -152,9 +152,9 @@ export async function handler(argv: Arguments) {
       return;
     }
     if(err.message.includes("MUX_TOKEN_ID environment variable is missing or empty") || err.message.includes("MUX_TOKEN_SECRET environment variable is missing or empty")){
-      log.error(err.message, "Visit https://next-video.dev/docs#remote-storage-and-optimization for more information.");
+      log.error(`${err.message} \x1b[4;34mVisit https://next-video.dev/docs#remote-storage-and-optimization\x1b[0m for more information.`);
       return;
-    }
+    }    
 
     log.error('An unknown error occurred', err);
   }

--- a/src/cli/sync.ts
+++ b/src/cli/sync.ts
@@ -152,7 +152,7 @@ export async function handler(argv: Arguments) {
       return;
     }
     if(err.message.includes("MUX_TOKEN_ID environment variable is missing or empty") || err.message.includes("MUX_TOKEN_SECRET environment variable is missing or empty")){
-      log.error(err.message, "Visit https://github.com/muxinc/next-video?tab=readme-ov-file#remote-storage-and-optimization for more information.");
+      log.error(err.message, "Visit https://next-video.dev/docs#remote-storage-and-optimization for more information.");
       return;
     }
 

--- a/src/providers/mux/provider.ts
+++ b/src/providers/mux/provider.ts
@@ -168,7 +168,11 @@ export async function uploadLocalFile(asset: Asset) {
         video_quality: muxConfig?.videoQuality,
       },
     });
-  } catch (e) {
+  } catch (e: any) {
+    if(e.status === 401){
+      log.error("Unauthorized request. Check that your MUX_TOKEN_ID and MUX_TOKEN_SECRET credentials are valid.");
+      return;
+    }
     log.error('Error creating a Mux Direct Upload');
     console.error(e);
     return;

--- a/src/providers/mux/provider.ts
+++ b/src/providers/mux/provider.ts
@@ -168,8 +168,8 @@ export async function uploadLocalFile(asset: Asset) {
         video_quality: muxConfig?.videoQuality,
       },
     });
-  } catch (e: any) {
-    if(e.status === 401){
+  } catch (e) {
+    if (e instanceof Error && 'status' in e && e.status === 401) {
       log.error("Unauthorized request. Check that your MUX_TOKEN_ID and MUX_TOKEN_SECRET credentials are valid.");
       return;
     }


### PR DESCRIPTION
Closes #52 
## Changes
- Missing Mux credentials now returns a known error, with a link to that specific section of next-video docs
- Enhanced error message when credentials are incorrect (but not empty)
## Screenshots
1. If `MUX_TOKEN_ID` or `.env.local` is missing:

![image](https://github.com/user-attachments/assets/e9969f91-cf53-4345-aefa-c5fcd319bd9c)
2. If `MUX_TOKEN_SECRET` is missing:

![image](https://github.com/user-attachments/assets/de676b7a-0812-41f5-84f3-0abfb67836a9)
3. If creds are incorrect:

![image](https://github.com/user-attachments/assets/608590f0-93ea-48e4-9afb-208cec9f82d9)
## Testing steps
- Start a project with no Mux creds, no `.env.local` or with incorrect creds
- Add a video to /videos
- Run `npx next-video sync`