### PR TITLE
fix: add a queue to throttle requests and avoid 429 errors

### DIFF
--- a/src/providers/mux/provider.ts
+++ b/src/providers/mux/provider.ts
@@ -53,6 +53,13 @@ async function startProcessingQueue() {
   }, 1000);
 }
 
+export function stopProcessingQueue() {
+  if (intervalId) {
+    clearInterval(intervalId);
+    intervalId = undefined;
+  }
+}
+
 function enqueueMethod<T>(fn: () => Promise<T>): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     requestQueue.push({ fn, resolve, reject });

--- a/src/providers/mux/provider.ts
+++ b/src/providers/mux/provider.ts
@@ -12,7 +12,7 @@ import { updateAsset, Asset } from '../../assets.js';
 import { getVideoConfig } from '../../config.js';
 import log from '../../utils/logger.js';
 import { sleep } from '../../utils/utils.js';
-import { startProcessingQueue, enqueueMethod } from '../../utils/queue.js';
+import { Queue } from '../../utils/queue.js';
 
 export type MuxMetadata = {
   uploadId?: string;
@@ -24,9 +24,11 @@ export type MuxMetadata = {
 // but we also don't want to need to initialize it every time in situations like polling.
 // So we'll initialize it lazily but cache the instance.
 let mux: Mux;
+export let queue: Queue;
 function initMux() {
   mux ??= new Mux();
-  startProcessingQueue();
+  queue ??= new Queue();
+  queue.startProcessingQueue();
 }
 
 async function pollForAssetReady(filePath: string, asset: Asset) {
@@ -181,7 +183,7 @@ export async function uploadLocalFile(asset: Asset) {
     return uploadRequestedFile(asset);
   }
 
-  const upload: Mux.Video.Uploads.Upload | undefined = await enqueueMethod(() => createUploadURL());
+  const upload: Mux.Video.Uploads.Upload | undefined = await queue.enqueueMethod(() => createUploadURL());
   if (!upload) {
     return;
   }

--- a/src/providers/mux/provider.ts
+++ b/src/providers/mux/provider.ts
@@ -24,11 +24,10 @@ export type MuxMetadata = {
 // but we also don't want to need to initialize it every time in situations like polling.
 // So we'll initialize it lazily but cache the instance.
 let mux: Mux;
-export let queue: Queue;
+let queue: Queue;
 function initMux() {
   mux ??= new Mux();
   queue ??= new Queue();
-  queue.startProcessingQueue();
 }
 
 async function pollForAssetReady(filePath: string, asset: Asset) {
@@ -183,7 +182,7 @@ export async function uploadLocalFile(asset: Asset) {
     return uploadRequestedFile(asset);
   }
 
-  const upload: Mux.Video.Uploads.Upload | undefined = await queue.enqueueMethod(() => createUploadURL());
+  const upload: Mux.Video.Uploads.Upload | undefined = await queue.enqueue(() => createUploadURL());
   if (!upload) {
     return;
   }

--- a/src/utils/queue.ts
+++ b/src/utils/queue.ts
@@ -14,13 +14,13 @@ export async function startProcessingQueue() {
     }
     intervalId = setInterval(async () => {
         if (requestQueue.length > 0) {
-        const { fn, resolve, reject } = requestQueue.shift() as QueueItem;
-        try {
-            const result = await fn();
-            resolve(result);
-        } catch (error) {
-            reject(error);
-        }
+            const { fn, resolve, reject } = requestQueue.shift() as QueueItem;
+            try {
+                const result = await fn();
+                resolve(result);
+            } catch (error) {
+                reject(error);
+            }
         }
     }, 1000);
 }

--- a/src/utils/queue.ts
+++ b/src/utils/queue.ts
@@ -1,0 +1,44 @@
+export interface QueueItem<T = any> {
+    fn: () => Promise<T>;
+    resolve: (value: T) => void;
+    reject: (reason?: any) => void;
+}
+
+let intervalId: NodeJS.Timeout | undefined = undefined;
+let firstItemInQueue: boolean = true;
+const requestQueue: QueueItem[] = [];
+
+export async function startProcessingQueue() {
+    if (intervalId) {
+        return;
+    }
+    intervalId = setInterval(async () => {
+        if (requestQueue.length > 0) {
+        const { fn, resolve, reject } = requestQueue.shift() as QueueItem;
+        try {
+            const result = await fn();
+            resolve(result);
+        } catch (error) {
+            reject(error);
+        }
+        }
+    }, 1000);
+}
+
+export function stopProcessingQueue() {
+  if (intervalId) {
+    clearInterval(intervalId);
+    intervalId = undefined;
+  }
+}
+
+export async function enqueueMethod<T>(fn: () => Promise<T>): Promise<T> {
+    if (firstItemInQueue) {
+        firstItemInQueue = false;
+        return await fn();
+    } else {
+        return new Promise<T>((resolve, reject) => {
+            requestQueue.push({ fn, resolve, reject });
+        });
+    }
+}

--- a/src/utils/queue.ts
+++ b/src/utils/queue.ts
@@ -1,54 +1,71 @@
 export interface QueueItem<T = any> {
-    fn: () => Promise<T>;
-    resolve: (value: T) => void;
-    reject: (reason?: any) => void;
+  fn: () => Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: any) => void;
 }
 
-export class Queue {
-    private intervalId: NodeJS.Timeout | undefined = undefined;
-    private firstItemInQueue: boolean = true;
-    private requestQueue: QueueItem[] = [];
-    private processingInterval: number;
+export class Queue {  
+  private lastRequestTime: number | null = null;
+  private requestQueue: QueueItem[] = [];
+  private processing = false;
+  private delayMs: number;
 
-    constructor(processingInterval: number = 1000) {
-        this.processingInterval = processingInterval;
+  constructor(delayMs: number = 1000) {    
+    this.delayMs = delayMs;
+  }
+
+  public async enqueue<T>(fn: () => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      this.requestQueue.push({ fn, resolve, reject });
+
+      if (!this.processing) {        
+        this.processNext();
+      }
+    });
+  }
+
+  private processNext() {
+    if (this.requestQueue.length === 0) {
+      this.processing = false;
+      return;
     }
 
-    public async startProcessingQueue(): Promise<void> {
-        if (this.intervalId) {
-            return;
-        }
-        this.intervalId = setInterval(async () => {
-            if (this.requestQueue.length > 0) {
-                const { fn, resolve, reject } = this.requestQueue.shift() as QueueItem;
-                try {
-                    const result = await fn();
-                    resolve(result);
-                } catch (error) {
-                    reject(error);
-                }
-            } else {
-                this.firstItemInQueue = true;
-            }
-        }, this.processingInterval);
+    this.processing = true;
+
+    if (this.lastRequestTime !== null) {
+      const elapsed = Date.now() - this.lastRequestTime;
+      const waitTime = this.delayMs - elapsed;
+
+      if (waitTime > 0) {
+        setTimeout(() => this.executeNextRequest(), waitTime);
+      } else {
+        this.executeNextRequest();
+      }
+    } else {
+      this.executeNextRequest();
+    }
+  }
+
+  private executeNextRequest() {
+    const item = this.requestQueue.shift();
+
+    if (!item) {
+      this.processing = false;
+      return;
     }
 
-    public stopProcessingQueue(): void {
-        if (this.intervalId) {
-            clearInterval(this.intervalId);
-            this.intervalId = undefined;
-            this.firstItemInQueue = true;
-        }
-    }
+    const { fn, resolve, reject } = item;
 
-    public async enqueueMethod<T>(fn: () => Promise<T>): Promise<T> {
-        if (this.firstItemInQueue) {
-            this.firstItemInQueue = false;
-            return await fn();
-        } else {
-            return new Promise<T>((resolve, reject) => {
-                this.requestQueue.push({ fn, resolve, reject });
-            });
-        }
-    }
+    fn()
+      .then((result) => {
+        resolve(result);
+      })
+      .catch((err) => {
+        reject(err);
+      })
+      .finally(() => {
+        this.lastRequestTime = Date.now();
+        this.processNext();
+      });
+  }
 }

--- a/tests/cli/sync.test.ts
+++ b/tests/cli/sync.test.ts
@@ -10,7 +10,7 @@ import log from '../../src/utils/logger.js';
 
 import { handler, builder } from '../../src/cli/sync.js';
 import { createAsset, updateAsset } from '../../src/assets.js';
-import { stopProcessingQueue } from '../../src/providers/mux/provider.js';
+import { stopProcessingQueue } from '../../src/utils/queue.js';
 
 import * as fakeMux from '../utils/fake-mux.js';
 
@@ -112,7 +112,7 @@ describe('cli', () => {
       const args = builder(yargs(`--dir ${dir}`)).parseSync();
 
       await handler(args);
-      
+
       assert(findConsoleMessage(addSpy, /found 1/i), 'Found 1 message not found');
     });
 

--- a/tests/cli/sync.test.ts
+++ b/tests/cli/sync.test.ts
@@ -10,6 +10,7 @@ import log from '../../src/utils/logger.js';
 
 import { handler, builder } from '../../src/cli/sync.js';
 import { createAsset, updateAsset } from '../../src/assets.js';
+import { stopProcessingQueue } from '../../src/providers/mux/provider.js';
 
 import * as fakeMux from '../utils/fake-mux.js';
 
@@ -81,6 +82,7 @@ describe('cli', () => {
 
   after(async () => {
     server.close();
+    stopProcessingQueue();
 
     for (const dir of tmpDirs) {
       await fs.rm(dir, { recursive: true, force: true });
@@ -110,7 +112,7 @@ describe('cli', () => {
       const args = builder(yargs(`--dir ${dir}`)).parseSync();
 
       await handler(args);
-
+      
       assert(findConsoleMessage(addSpy, /found 1/i), 'Found 1 message not found');
     });
 

--- a/tests/cli/sync.test.ts
+++ b/tests/cli/sync.test.ts
@@ -10,7 +10,7 @@ import log from '../../src/utils/logger.js';
 
 import { handler, builder } from '../../src/cli/sync.js';
 import { createAsset, updateAsset } from '../../src/assets.js';
-import { stopProcessingQueue } from '../../src/utils/queue.js';
+import { queue } from '../../src/providers/mux/provider.js';
 
 import * as fakeMux from '../utils/fake-mux.js';
 
@@ -82,7 +82,9 @@ describe('cli', () => {
 
   after(async () => {
     server.close();
-    stopProcessingQueue();
+    if (queue) {
+      queue.stopProcessingQueue();
+    }
 
     for (const dir of tmpDirs) {
       await fs.rm(dir, { recursive: true, force: true });

--- a/tests/cli/sync.test.ts
+++ b/tests/cli/sync.test.ts
@@ -10,7 +10,6 @@ import log from '../../src/utils/logger.js';
 
 import { handler, builder } from '../../src/cli/sync.js';
 import { createAsset, updateAsset } from '../../src/assets.js';
-import { queue } from '../../src/providers/mux/provider.js';
 
 import * as fakeMux from '../utils/fake-mux.js';
 
@@ -82,9 +81,6 @@ describe('cli', () => {
 
   after(async () => {
     server.close();
-    if (queue) {
-      queue.stopProcessingQueue();
-    }
 
     for (const dir of tmpDirs) {
       await fs.rm(dir, { recursive: true, force: true });


### PR DESCRIPTION
Closes #309 

- Created a queue that limits the creation of upload URLs to one per second, preventing "Too Many Requests" (429) errors.