### PR TITLE
feat: allow configurable fetchPriority for poster image

### DIFF
--- a/src/components/players/background-player.tsx
+++ b/src/components/players/background-player.tsx
@@ -10,7 +10,7 @@ import type { MediaProps } from './media/index.js';
 
 const BackgroundPlayer = forwardRef<HTMLVideoElement, Omit<MediaProps, 'ref'> & PlayerProps>(
   (allProps, forwardedRef) => {
-    let { style, className, children, asset, poster, blurDataURL, onPlaying, onLoadStart, ...rest } = allProps;
+    let { style, className, children, asset, poster, posterFetchPriority="auto", blurDataURL, onPlaying, onLoadStart, ...rest } = allProps;
 
     const slottedPoster = Children.toArray(children).find((child) => {
       return typeof child === 'object' && 'type' in child && (child.props as any).slot === 'poster';
@@ -137,6 +137,7 @@ const BackgroundPlayer = forwardRef<HTMLVideoElement, Omit<MediaProps, 'ref'> & 
                 hidden={posterHidden}
                 decoding="async"
                 aria-hidden="true"
+                fetchPriority={posterFetchPriority}
               />
             )}
             <div className="next-video-bg-text">{children}</div>

--- a/src/components/players/default-player.tsx
+++ b/src/components/players/default-player.tsx
@@ -16,6 +16,7 @@ const DefaultPlayer = forwardRef<HTMLVideoElement, Omit<MediaProps, 'ref'> & Pla
     asset,
     controls = true,
     poster,
+    posterFetchPriority = 'auto',
     blurDataURL,
     theme: Theme = Sutro,
     ...rest
@@ -96,6 +97,7 @@ const DefaultPlayer = forwardRef<HTMLVideoElement, Omit<MediaProps, 'ref'> & Pla
           style={imgStyleProps}
           decoding="async"
           aria-hidden="true"
+          fetchPriority={posterFetchPriority}
         />
       );
       poster = '';

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -133,6 +133,11 @@ export type PlayerProps = {
   poster?: StaticImageData | string;
 
   /**
+   * The poster image fetch priority for the video.
+   */
+  posterFetchPriority?: 'high' | 'low' | 'auto';
+
+  /**
    * Set a manual data URL to be used as a placeholder image before the poster image successfully loads.
    * For imported videos this will be automatically generated.
    */


### PR DESCRIPTION
This adds an optional `posterFetchPriority` prop (`"high"` | `"low"` | `"auto"`) to `next-video`.

By default, it’s `"auto"`, matching native behavior.
But in common use cases - e.g. background videos shown immediately on page load - PageSpeed Insights recommends setting the poster image to `fetchPriority="high"` to improve LCP.

This gives users control to apply it only when appropriate.

![CleanShot 2025-05-20 at 15 56 49@2x](https://github.com/user-attachments/assets/681c9a38-350e-483b-9d51-8266f993ca2d)