### PR TITLE
docs: Add lazy-loading example for video on user interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,7 +514,7 @@ export { GET, POST } from '@/next-video';
 export { handler as default } from '@/next-video';
 ```
 
-### Lazy Load Player Based on User Interaction ([Demo](https://codesandbox.io/p/devbox/2w5n52))
+### Lazy Load Player Based on User Interaction ([Demo](https://codesandbox.io/p/devbox/next-video-lazy-load-based-on-user-interaction-w857r5))
 
 You can delay loading the full video player until the user shows real intent to watch. This reduces initial data usage and improves performance, especially when rendering multiple videos.
 
@@ -555,7 +555,7 @@ How It Works:
 	•	This ensures no network requests or DOM elements for the video are loaded until necessary.
 	•	You can adapt this pattern for hover, scroll, or other interactions to trigger lazy loading.
 
- [Live Demo](https://codesandbox.io/p/devbox/2w5n52)
+ [Live Demo](https://codesandbox.io/p/devbox/next-video-lazy-load-based-on-user-interaction-w857r5)
 
 ## Default Player
 


### PR DESCRIPTION
Resolves [349](https://github.com/muxinc/next-video/issues/349) 

Updates the documentation to include a new section demonstrating how to lazy-load the <Video> component based on user interaction. 

The example shows a simple wrapper component that renders a poster and play button initially, and only mounts the actual video element when the user clicks (or hovers). 

This approach helps reduce initial data usage and improves page performance, especially when multiple videos are rendered.