### PR TITLE
fix: Upgraded players and media chrome to use new ce-la-react

### DIFF
--- a/examples/default-provider/package-lock.json
+++ b/examples/default-provider/package-lock.json
@@ -11,7 +11,7 @@
         "next": "15.5.0",
         "next-video": "file:../..",
         "open-props": "^1.7.8",
-        "player.style": "^0.3.0",
+        "player.style": "^0.3.1",
         "react": "^19",
         "react-dom": "^19",
         "react-player": "^3.3.1"
@@ -44,7 +44,7 @@
         "magicast": "^0.3.5",
         "media-chrome": "^4.16.1",
         "minimatch": "^10.0.3",
-        "player.style": "^0.3.0",
+        "player.style": "^0.3.1",
         "resolve": "^1.22.10",
         "symlink-dir": "^6.0.3",
         "undici": "^5.28.4",
@@ -3823,6 +3823,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/media-chrome": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-4.16.1.tgz",
+      "integrity": "sha512-qtFlsy0lNDVCyVo//ZCAfRPKwgehfOYp6rThZzDUuZ5ypv41yqUfAxK+P9TOs+XSVWXATPTT2WRV0fbW0BH4vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ce-la-react": "^0.3.2"
+      }
+    },
     "node_modules/media-tracks": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/media-tracks/-/media-tracks-0.3.3.tgz",
@@ -4203,9 +4212,9 @@
       }
     },
     "node_modules/player.style": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/player.style/-/player.style-0.3.0.tgz",
-      "integrity": "sha512-ny1TbqA2ZsUd6jzN+F034+UMXVK7n5SrwepsrZ2gIqVz00Hn0ohCUbbUdst/2IOFCy0oiTbaOXkSFxRw1RmSlg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/player.style/-/player.style-0.3.1.tgz",
+      "integrity": "sha512-z/T8hJGaTkHT9vdXgWdOgF37eB1FV7/j52VXQZ2lgEhpru9oT8TaUWIxp6GoxTnhPBM4X6nSbpkAHrT7UTjUKg==",
       "license": "MIT",
       "workspaces": [
         ".",
@@ -4215,16 +4224,7 @@
         "themes/*"
       ],
       "dependencies": {
-        "media-chrome": "~4.14.0"
-      }
-    },
-    "node_modules/player.style/node_modules/media-chrome": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-4.14.0.tgz",
-      "integrity": "sha512-IEdFb4blyF15vLvQzLIn6USJBv7Kf2ne+TfLQKBYI5Z0f9VEBVZz5MKy4Uhi0iA9lStl2S9ENIujJRuJIa5OiA==",
-      "license": "MIT",
-      "dependencies": {
-        "ce-la-react": "^0.3.0"
+        "media-chrome": "~4.16.1"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/examples/default-provider/package.json
+++ b/examples/default-provider/package.json
@@ -12,7 +12,7 @@
     "next": "15.5.0",
     "next-video": "file:../..",
     "open-props": "^1.7.8",
-    "player.style": "^0.3.0",
+    "player.style": "^0.3.1",
     "react": "^19",
     "react-dom": "^19",
     "react-player": "^3.3.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "magicast": "^0.3.5",
         "media-chrome": "^4.16.1",
         "minimatch": "^10.0.3",
-        "player.style": "^0.3.0",
+        "player.style": "^0.3.1",
         "resolve": "^1.22.10",
         "symlink-dir": "^6.0.3",
         "undici": "^5.28.4",
@@ -4807,9 +4807,9 @@
       "license": "ISC"
     },
     "node_modules/player.style": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/player.style/-/player.style-0.3.0.tgz",
-      "integrity": "sha512-ny1TbqA2ZsUd6jzN+F034+UMXVK7n5SrwepsrZ2gIqVz00Hn0ohCUbbUdst/2IOFCy0oiTbaOXkSFxRw1RmSlg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/player.style/-/player.style-0.3.1.tgz",
+      "integrity": "sha512-z/T8hJGaTkHT9vdXgWdOgF37eB1FV7/j52VXQZ2lgEhpru9oT8TaUWIxp6GoxTnhPBM4X6nSbpkAHrT7UTjUKg==",
       "license": "MIT",
       "workspaces": [
         ".",
@@ -4819,16 +4819,7 @@
         "themes/*"
       ],
       "dependencies": {
-        "media-chrome": "~4.14.0"
-      }
-    },
-    "node_modules/player.style/node_modules/media-chrome": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-4.14.0.tgz",
-      "integrity": "sha512-IEdFb4blyF15vLvQzLIn6USJBv7Kf2ne+TfLQKBYI5Z0f9VEBVZz5MKy4Uhi0iA9lStl2S9ENIujJRuJIa5OiA==",
-      "license": "MIT",
-      "dependencies": {
-        "ce-la-react": "^0.3.0"
+        "media-chrome": "~4.16.1"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "magicast": "^0.3.5",
     "media-chrome": "^4.16.1",
     "minimatch": "^10.0.3",
-    "player.style": "^0.3.0",
+    "player.style": "^0.3.1",
     "resolve": "^1.22.10",
     "symlink-dir": "^6.0.3",
     "undici": "^5.28.4",


### PR DESCRIPTION
Closes https://github.com/muxinc/next-video/issues/397 

Relates to https://github.com/muxinc/ce-la-react/pull/7

Upgrades ce-la-react to prevent missing key warning when using custom components on SSR. This is done by updating all dependencies that depend on ce-la-react.