### PR TITLE
fix: Remove Suspense to Forward ref correctly

### DIFF
--- a/src/components/players/default-player.tsx
+++ b/src/components/players/default-player.tsx
@@ -107,7 +107,6 @@ const DefaultPlayer = forwardRef<HTMLVideoElement, Omit<MediaProps, 'ref'> & Pla
         ...style,
       }}>
         {slottedPosterImg}
-        <Suspense fallback={null}>
           <Media
             suppressHydrationWarning
             ref={forwardedRef}
@@ -129,13 +128,11 @@ const DefaultPlayer = forwardRef<HTMLVideoElement, Omit<MediaProps, 'ref'> & Pla
             )}
             {children}
           </Media>
-        </Suspense>
       </Theme>
     );
   }
 
   return (
-    <Suspense fallback={null}>
       <Media
         suppressHydrationWarning
         ref={forwardedRef}
@@ -158,7 +155,6 @@ const DefaultPlayer = forwardRef<HTMLVideoElement, Omit<MediaProps, 'ref'> & Pla
         )}
         {children}
       </Media>
-    </Suspense>
   );
 });
 


### PR DESCRIPTION
This PR fixes issue [#392](https://github.com/muxinc/next-video/issues/392) where using a ref on the <Player> component did not provide access to the underlying video element, preventing useEffect and other ref-based logic from working.

Changes:
- Removed Suspense wrapping around Media components.
- Ensured DefaultPlayer forwards the ref correctly to Media and ultimately to the DOM/video element.
