### PR TITLE
feat: upgrade Vercel Blob version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@mux/playback-core": "^0.31.4",
         "@next/env": "15.5.9",
         "@paralleldrive/cuid2": "^2.2.2",
-        "@vercel/blob": "^0.27.0",
+        "@vercel/blob": "^2.0.0",
         "chalk": "^4.1.2",
         "chokidar": "^4.0.3",
         "dash-video-element": "^0.3.1",
@@ -3438,9 +3438,9 @@
       "license": "MIT"
     },
     "node_modules/@vercel/blob": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-0.27.3.tgz",
-      "integrity": "sha512-WizeAxzOTmv0JL7wOaxvLIU/KdBcrclM1ZUOdSlIZAxsTTTe1jsyBthStLby0Ueh7FnmKYAjLz26qRJTk5SDkQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.0.0.tgz",
+      "integrity": "sha512-oAj7Pdy83YKSwIaMFoM7zFeLYWRc+qUpW3PiDSblxQMnGFb43qs4bmfq7dr/+JIfwhs6PTwe1o2YBwKhyjWxXw==",
       "license": "Apache-2.0",
       "dependencies": {
         "async-retry": "^1.3.3",
@@ -3450,7 +3450,7 @@
         "undici": "^5.28.4"
       },
       "engines": {
-        "node": ">=16.14"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@zkochan/rimraf": {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@mux/playback-core": "^0.31.4",
     "@next/env": "15.5.9",
     "@paralleldrive/cuid2": "^2.2.2",
-    "@vercel/blob": "^0.27.0",
+    "@vercel/blob": "^2.0.0",
     "chalk": "^4.1.2",
     "chokidar": "^4.0.3",
     "dash-video-element": "^0.3.1",

--- a/src/providers/vercel-blob/provider.ts
+++ b/src/providers/vercel-blob/provider.ts
@@ -86,7 +86,7 @@ async function putAsset(filePath: string, size: number, stream: ReadStream | Rea
   let blob;
   try {
     key = await createAssetKey(filePath, 'vercel-blob');
-    blob = await put(key, stream, { access: 'public' });
+    blob = await put(key, stream, { access: 'public', addRandomSuffix: true });
 
     if (stream instanceof ReadStream) {
       stream.close();


### PR DESCRIPTION
This PR closes #375 

Upgrades @vercel/blob from ^0.27.0 to ^2.0.0. Adds addRandomSuffix: true to the put call in vercel-blob/provider.ts to maintain backward compatibility, since the default changed from true to false in v1.0.0. The v2.0.0 breaking change only affects handleUpload and onUploadCompleted, which we don't use.