### PR TITLE
fix: streamline NODE_ENV access in isDevMode

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "types:cjs": "tsc --outDir dist/cjs",
     "prebuild": "npm run clean && npm run types",
     "build": "npm run build:esm && npm run build:cjs",
-    "build:esm": "esbuild \"src/**/*.ts*\" --outdir=dist --format=esm --target=es2020",
+    "build:esm": "esbuild \"src/**/*.ts*\" --outdir=dist --format=esm --target=es2020 --define:process.env.NODE_ENV=process.env.NODE_ENV",
     "build:cjs": "esbuild \"src/**/*.ts*\" --outdir=dist/cjs --platform=node --format=cjs --target=es2020 --define:import.meta.url=\\\"\\\"",
     "postbuild:cjs": "node --eval \"fs.writeFileSync('./dist/cjs/package.json', '{\\\"type\\\": \\\"commonjs\\\"}')\"",
     "prepare": "npm run build",

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -103,7 +103,5 @@ export function svgBlurImage(blurDataURL: string) {
 }
 
 export function isDevMode(): boolean {
-  // Indirect access prevents esbuild/webpack from replacing NODE_ENV at build time
-  const env = process.env;
-  return env.NODE_ENV === 'development';
+  return process.env.NODE_ENV === 'development';
 }


### PR DESCRIPTION
fixes #422

The previous fix (#410) used const env = process.env to dodge esbuild's NODE_ENV inlining, but that also defeated the consumer's webpack DefinePlugin, leaving a live process.env reference in the client bundle.

This moves the workaround from source to build config:

src/components/utils.ts: revert to direct process.env.NODE_ENV === 'development'.
package.json: add --define:process.env.NODE_ENV=process.env.NODE_ENV to build:esm so esbuild leaves the token intact for the consumer's bundler to substitute.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to environment gating and build config; main risk is altered dev/prod branching if build-time defines behave differently across consumer setups.
> 
> **Overview**
> Ensures `isDevMode()` can be optimized by downstream bundlers again by reverting it to a direct `process.env.NODE_ENV === 'development'` check.
> 
> Updates the ESM esbuild command to explicitly `--define:process.env.NODE_ENV=process.env.NODE_ENV`, preventing esbuild from inlining/replacing the value during library build while still allowing consumers (e.g., webpack `DefinePlugin`) to substitute it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b96e14a2b5bb1ee2e3fa6d69b952d01e1bb232b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->